### PR TITLE
MultiEditor plugin bug fixes

### DIFF
--- a/UoFiddler.Plugin.MultiEditor/Classes/MultiEditorComponentList.cs
+++ b/UoFiddler.Plugin.MultiEditor/Classes/MultiEditorComponentList.cs
@@ -175,13 +175,13 @@ namespace UoFiddler.Plugin.MultiEditor.Classes
 
             if (drawFloor)
             {
-                int floorZMod = -_parent.DrawFloorZ << 2 - 44; // TODO: that shift count is what -42?
+                int floorZMod = (-_parent.DrawFloorZ * 4) - 44;
                 if (YMin > floorZMod)
                 {
                     YMin = floorZMod;
                 }
 
-                floorZMod = ((Width + Height) * 22) - _parent.DrawFloorZ << 2;
+                floorZMod = ((Width + Height) * 22) - (_parent.DrawFloorZ * 4);
                 if (YMaxOrg < floorZMod)
                 {
                     YMax = floorZMod;

--- a/UoFiddler.Plugin.MultiEditor/UserControls/MultiEditor.cs
+++ b/UoFiddler.Plugin.MultiEditor/UserControls/MultiEditor.cs
@@ -401,6 +401,11 @@ namespace UoFiddler.Plugin.MultiEditor.UserControls
         /// </summary>
         private void NumericUpDown_Floor_Changed(object sender, EventArgs e)
         {
+            if (_compList is null)
+            {
+                return;
+            }
+
             DrawFloorZ = (int)numericUpDown_Floor.Value;
             _compList.SetFloorZ(DrawFloorZ);
             if (!BTN_Floor.Checked)


### PR DESCRIPTION
Fixed bug with invisible virtual floor for Z values greater than 0. 
Fixed crash when setting virtual floor level without creating or importing new design first.