### PR TITLE
Set of fixes

### DIFF
--- a/Ultima/Art.cs
+++ b/Ultima/Art.cs
@@ -9,7 +9,7 @@ namespace Ultima
     public static class Art
     {
         private static FileIndex _fileIndex = new FileIndex(
-        "Artidx.mul", "Art.mul", "artLegacyMUL.uop", 0x10000, 4, ".tga", 0x13FDC, false);
+        "Artidx.mul", "Art.mul", "artLegacyMUL.uop", 0x14000, 4, ".tga", 0x13FDC, false);
         private static Bitmap[] _cache;
         private static bool[] _removed;
         private static readonly Dictionary<int, bool> _patched = new Dictionary<int, bool>();
@@ -87,7 +87,7 @@ namespace Ultima
         public static void Reload()
         {
             _fileIndex = new FileIndex(
-                "Artidx.mul", "Art.mul", "artLegacyMUL.uop", 0x10000, 4, ".tga", 0x13FDC, false);
+                "Artidx.mul", "Art.mul", "artLegacyMUL.uop", 0x14000, 4, ".tga", 0x13FDC, false);
             _cache = new Bitmap[0x14000];
             _removed = new bool[0x14000];
             _patched.Clear();

--- a/UoFiddler.Controls/Forms/AnimationEditForm.cs
+++ b/UoFiddler.Controls/Forms/AnimationEditForm.cs
@@ -13,6 +13,7 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
+using System.Linq;
 using System.Windows.Forms;
 using Ultima;
 using UoFiddler.Controls.Classes;
@@ -113,7 +114,7 @@ namespace UoFiddler.Controls.Forms
                         nodes[i] = node;
                     }
 
-                    treeView1.Nodes.AddRange(nodes);
+                    treeView1.Nodes.AddRange(nodes.Where(n => n != null).ToArray());
                 }
             }
             finally
@@ -154,19 +155,9 @@ namespace UoFiddler.Controls.Forms
 
         private TreeNode GetNode(int tag)
         {
-            if (_showOnlyValid)
-            {
-                foreach (TreeNode node in treeView1.Nodes)
-                {
-                    if ((int)node.Tag == tag)
-                    {
-                        return node;
-                    }
-                }
-                return null;
-            }
-
-            return treeView1.Nodes[tag];
+            return _showOnlyValid 
+                ? treeView1.Nodes.Cast<TreeNode>().FirstOrDefault(node => (int)node.Tag == tag) 
+                : treeView1.Nodes[tag];
         }
 
         private unsafe void SetPaletteBox()
@@ -742,9 +733,9 @@ namespace UoFiddler.Controls.Forms
                         try
                         {
                             //My Soulblighter Modifications
-                            for (int w = 0; w < dialog.FileNames.Length; w++)
+                            foreach (var fileName in dialog.FileNames)
                             {
-                                Bitmap bmp = new Bitmap(dialog.FileNames[w]); // dialog.Filename replaced by dialog.FileNames[w]
+                                Bitmap bmp = new Bitmap(fileName);
                                 AnimIdx edit = AnimationEdit.GetAnimation(_fileType, _currentBody, _currentAction, _currentDir);
                                 if (dialog.FileName.Contains(".bmp") || dialog.FileName.Contains(".tiff") || dialog.FileName.Contains(".png") || dialog.FileName.Contains(".jpeg") || dialog.FileName.Contains(".jpg"))
                                 {

--- a/UoFiddler.Controls/UoFiddler.Controls.csproj
+++ b/UoFiddler.Controls/UoFiddler.Controls.csproj
@@ -516,6 +516,6 @@
     <None Include="Resources\staticPlayButton.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
   </ItemGroup>
 </Project>

--- a/UoFiddler.Controls/UserControls/AnimationListControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/AnimationListControl.Designer.cs
@@ -282,7 +282,7 @@ namespace UoFiddler.Controls.UserControls
             this.tabPage2.Location = new System.Drawing.Point(4, 22);
             this.tabPage2.Name = "tabPage2";
             this.tabPage2.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage2.Size = new System.Drawing.Size(407, 280);
+            this.tabPage2.Size = new System.Drawing.Size(410, 281);
             this.tabPage2.TabIndex = 1;
             this.tabPage2.Text = "Thumbnail List";
             this.tabPage2.UseVisualStyleBackColor = true;
@@ -298,7 +298,7 @@ namespace UoFiddler.Controls.UserControls
             this.listView.MultiSelect = false;
             this.listView.Name = "listView";
             this.listView.OwnerDraw = true;
-            this.listView.Size = new System.Drawing.Size(401, 274);
+            this.listView.Size = new System.Drawing.Size(404, 275);
             this.listView.TabIndex = 0;
             this.listView.TileSize = new System.Drawing.Size(81, 110);
             this.listView.UseCompatibleStateImageBehavior = false;
@@ -313,7 +313,7 @@ namespace UoFiddler.Controls.UserControls
             this.tabPage3.Location = new System.Drawing.Point(4, 22);
             this.tabPage3.Name = "tabPage3";
             this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage3.Size = new System.Drawing.Size(407, 280);
+            this.tabPage3.Size = new System.Drawing.Size(410, 281);
             this.tabPage3.TabIndex = 2;
             this.tabPage3.Text = "Frames";
             this.tabPage3.UseVisualStyleBackColor = true;
@@ -327,7 +327,7 @@ namespace UoFiddler.Controls.UserControls
             this.listView1.MultiSelect = false;
             this.listView1.Name = "listView1";
             this.listView1.OwnerDraw = true;
-            this.listView1.Size = new System.Drawing.Size(401, 274);
+            this.listView1.Size = new System.Drawing.Size(404, 275);
             this.listView1.TabIndex = 0;
             this.listView1.TileSize = new System.Drawing.Size(81, 110);
             this.listView1.UseCompatibleStateImageBehavior = false;
@@ -472,26 +472,24 @@ namespace UoFiddler.Controls.UserControls
             // 
             // BaseGraphicLabel
             // 
-            this.BaseGraphicLabel.AutoSize = false;
             this.BaseGraphicLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.BaseGraphicLabel.Name = "BaseGraphicLabel";
             this.BaseGraphicLabel.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.BaseGraphicLabel.Size = new System.Drawing.Size(100, 17);
+            this.BaseGraphicLabel.Size = new System.Drawing.Size(75, 17);
             this.BaseGraphicLabel.Text = "BaseGraphic:";
             this.BaseGraphicLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // HueLabel
             // 
-            this.HueLabel.AutoSize = false;
             this.HueLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
             this.HueLabel.ImageAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.HueLabel.Name = "HueLabel";
             this.HueLabel.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.HueLabel.Size = new System.Drawing.Size(60, 17);
+            this.HueLabel.Size = new System.Drawing.Size(32, 17);
             this.HueLabel.Text = "Hue:";
             this.HueLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
-            // AnimationList
+            // AnimationListControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;

--- a/UoFiddler.Controls/UserControls/AnimationListControl.cs
+++ b/UoFiddler.Controls/UserControls/AnimationListControl.cs
@@ -385,9 +385,9 @@ namespace UoFiddler.Controls.UserControls
                     if (_frames[0].Bitmap != null)
                     {
                         _mainPicture = new Bitmap(_frames[0].Bitmap);
-                        BaseGraphicLabel.Text = $"BaseGraphic: {body}";
-                        GraphicLabel.Text = $"Graphic: {_currentSelect}(0x{_currentSelect:X})";
-                        HueLabel.Text = $"Hue: {hue + 1}";
+                        BaseGraphicLabel.Text = $"BaseGraphic: {body} (0x{body:X})";
+                        GraphicLabel.Text = $"Graphic: {_currentSelect} (0x{_currentSelect:X})";
+                        HueLabel.Text = $"Hue: {hue + 1} (0x{hue + 1:X})";
                     }
                     else
                     {
@@ -428,9 +428,9 @@ namespace UoFiddler.Controls.UserControls
                 return null;
             }
 
-            BaseGraphicLabel.Text = $"BaseGraphic: {body}";
-            GraphicLabel.Text = $"Graphic: {_currentSelect}(0x{_currentSelect:X})";
-            HueLabel.Text = $"Hue: {hue + 1}";
+            BaseGraphicLabel.Text = $"BaseGraphic: {body} (0x{body:X})";
+            GraphicLabel.Text = $"Graphic: {_currentSelect} (0x{_currentSelect:X})";
+            HueLabel.Text = $"Hue: {hue + 1} (0x{hue + 1:X})";
             int count = _frames.Length;
             _animationList = new Bitmap[count];
 
@@ -586,7 +586,7 @@ namespace UoFiddler.Controls.UserControls
                     string name = xMob.GetAttribute("name");
                     int value = int.Parse(xMob.GetAttribute("body"));
                     int type = int.Parse(xMob.GetAttribute("type"));
-                    node = new TreeNode(name)
+                    node = new TreeNode($"{name} (0x{value:X})")
                     {
                         Tag = new[] { value, type },
                         ToolTipText = Animations.GetFileName(value)

--- a/UoFiddler.Controls/UserControls/MultisControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/MultisControl.Designer.cs
@@ -261,28 +261,28 @@ namespace UoFiddler.Controls.UserControls
             // aToolStripMenuItem
             // 
             this.aToolStripMenuItem.Name = "aToolStripMenuItem";
-            this.aToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            this.aToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.aToolStripMenuItem.Text = "As Bmp";
             this.aToolStripMenuItem.Click += new System.EventHandler(this.OnClick_SaveAllBmp);
             // 
             // asTiffToolStripMenuItem1
             // 
             this.asTiffToolStripMenuItem1.Name = "asTiffToolStripMenuItem1";
-            this.asTiffToolStripMenuItem1.Size = new System.Drawing.Size(115, 22);
+            this.asTiffToolStripMenuItem1.Size = new System.Drawing.Size(180, 22);
             this.asTiffToolStripMenuItem1.Text = "As Tiff";
             this.asTiffToolStripMenuItem1.Click += new System.EventHandler(this.OnClick_SaveAllTiff);
             // 
             // asJpgToolStripMenuItem
             // 
             this.asJpgToolStripMenuItem.Name = "asJpgToolStripMenuItem";
-            this.asJpgToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            this.asJpgToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.asJpgToolStripMenuItem.Text = "As Jpg";
             this.asJpgToolStripMenuItem.Click += new System.EventHandler(this.OnClick_SaveAllJpg);
             // 
             // asPngToolStripMenuItem1
             // 
             this.asPngToolStripMenuItem1.Name = "asPngToolStripMenuItem1";
-            this.asPngToolStripMenuItem1.Size = new System.Drawing.Size(115, 22);
+            this.asPngToolStripMenuItem1.Size = new System.Drawing.Size(180, 22);
             this.asPngToolStripMenuItem1.Text = "As Png";
             this.asPngToolStripMenuItem1.Click += new System.EventHandler(this.OnClick_SaveAllPng);
             // 

--- a/UoFiddler.Controls/UserControls/MultisControl.cs
+++ b/UoFiddler.Controls/UserControls/MultisControl.cs
@@ -375,13 +375,18 @@ namespace UoFiddler.Controls.UserControls
 
             int selectedMaxHeight = HeightChangeMulti.Maximum - HeightChangeMulti.Value;
 
-            using (Bitmap multiBitmap = ((MultiComponentList)TreeViewMulti.SelectedNode.Tag).GetImage(selectedMaxHeight))
+            using (Bitmap multiBitmap = ((MultiComponentList)TreeViewMulti.SelectedNode.Tag)?.GetImage(selectedMaxHeight))
             {
-                SaveImage(multiBitmap, fileName, imageFormat, backgroundColor);
-            }
+                if (multiBitmap == null)
+                {
+                    return;
+                }
 
-            MessageBox.Show($"Multi saved to {fileName}", "Saved", MessageBoxButtons.OK, MessageBoxIcon.Information,
-                MessageBoxDefaultButton.Button1);
+                SaveImage(multiBitmap, fileName, imageFormat, backgroundColor);
+
+                MessageBox.Show($"Multi saved to {fileName}", "Saved", MessageBoxButtons.OK, MessageBoxIcon.Information,
+                    MessageBoxDefaultButton.Button1);
+            }
         }
 
         private static void SaveImage(Image sourceImage, string fileName, ImageFormat imageFormat, Color backgroundColor)
@@ -637,10 +642,15 @@ namespace UoFiddler.Controls.UserControls
                     }
 
                     const int maximumMultiHeight = 127;
+                    
                     string fileName = Path.Combine(dialog.SelectedPath, $"Multi 0x{index:X4}.{fileExtension}");
-                    using (Bitmap multiBitmap = ((MultiComponentList)_refMarker.TreeViewMulti.Nodes[i].Tag).GetImage(maximumMultiHeight))
+                    
+                    using (Bitmap multiBitmap = ((MultiComponentList)_refMarker.TreeViewMulti.Nodes[i].Tag)?.GetImage(maximumMultiHeight))
                     {
-                        SaveImage(multiBitmap, fileName, imageFormat, backgroundColor);
+                        if (multiBitmap != null)
+                        {
+                            SaveImage(multiBitmap, fileName, imageFormat, backgroundColor);
+                        }
                     }
                 }
 

--- a/UoFiddler.Controls/UserControls/TextureAlternativeControl.cs
+++ b/UoFiddler.Controls/UserControls/TextureAlternativeControl.cs
@@ -90,7 +90,7 @@ namespace UoFiddler.Controls.UserControls
             Cursor.Current = Cursors.WaitCursor;
             Options.LoadedUltimaClass["Texture"] = true;
 
-            for (int i = 0; i < 0x1000; ++i)
+            for (int i = 0; i < Textures.GetIdxLength(); ++i)
             {
                 if (Textures.TestTexture(i))
                 {

--- a/UoFiddler.Plugin.Compare/ComparePluginBase.cs
+++ b/UoFiddler.Plugin.Compare/ComparePluginBase.cs
@@ -10,6 +10,7 @@
  ***************************************************************************/
 
 using System.Windows.Forms;
+using Ultima;
 using UoFiddler.Controls.Plugin;
 using UoFiddler.Controls.Plugin.Interfaces;
 using UoFiddler.Plugin.Compare.UserControls;
@@ -52,6 +53,7 @@ namespace UoFiddler.Plugin.Compare
 
         public override void Initialize()
         {
+            _ = Files.RootDir;
         }
 
         public override void Dispose()

--- a/UoFiddler.Plugin.ExamplePlugin/ExamplePluginBase.cs
+++ b/UoFiddler.Plugin.ExamplePlugin/ExamplePluginBase.cs
@@ -61,6 +61,7 @@ namespace UoFiddler.Plugin.ExamplePlugin
         public override void Initialize()
         {
             // make something useful
+            _ = Files.RootDir;
         }
 
         public override void Dispose()

--- a/UoFiddler.Plugin.MassImport/MassImportPluginBase.cs
+++ b/UoFiddler.Plugin.MassImport/MassImportPluginBase.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Windows.Forms;
+using Ultima;
 using UoFiddler.Controls.Plugin;
 using UoFiddler.Controls.Plugin.Interfaces;
 
@@ -43,7 +44,10 @@ namespace UoFiddler.Plugin.MassImport
         /// </summary>
         public override IPluginHost Host { get; set; } = null;
 
-        public override void Initialize() { }
+        public override void Initialize()
+        {
+            _ = Files.RootDir;
+        }
 
         public override void Dispose() { }
 

--- a/UoFiddler.Plugin.MultiEditor/MultiEditorPluginBase.cs
+++ b/UoFiddler.Plugin.MultiEditor/MultiEditorPluginBase.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Windows.Forms;
+using Ultima;
 using UoFiddler.Controls.Classes;
 using UoFiddler.Controls.Plugin;
 using UoFiddler.Controls.Plugin.Interfaces;
@@ -59,6 +60,7 @@ namespace UoFiddler.Plugin.MultiEditor
         public override void Initialize()
         {
             // fired on fiddler startup
+            _ = Files.RootDir;
         }
 
         public override void ModifyPluginToolStrip(ToolStripDropDownButton toolStrip)

--- a/UoFiddler.Plugin.SendItem/SendItem.cs
+++ b/UoFiddler.Plugin.SendItem/SendItem.cs
@@ -77,6 +77,8 @@ namespace UoFiddler.Plugin.SendItem
 
         public override void Initialize()
         {
+            _ = Files.RootDir;
+
             LoadXml();
             ChangeOverrideClick(OverrideClick, true);
         }

--- a/UoFiddler.Plugin.UopPacker/UopPacker.cs
+++ b/UoFiddler.Plugin.UopPacker/UopPacker.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Windows.Forms;
+using Ultima;
 using UoFiddler.Controls.Plugin;
 using UoFiddler.Controls.Plugin.Interfaces;
 using UoFiddler.Plugin.UopPacker.UserControls;
@@ -53,6 +54,7 @@ namespace UoFiddler.Plugin.UopPacker
 
         public override void Initialize()
         {
+            _ = Files.RootDir;
         }
 
         public override void Dispose()

--- a/UoFiddler/UoFiddler.csproj
+++ b/UoFiddler/UoFiddler.csproj
@@ -150,7 +150,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Octokit" Version="0.48.0" />
-    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Fixed textures not showing in alternative design mode.
- Fixed missing tiles from art tab - the max id was without 4k landtiles offset. This only occurred in never clients when id was over 0x10000.
- Fixed wrong path setting when multiple UO clients are installed. It's workaround but will do for now. Fixes #64 
- Fixed crash when exporting images in multis tab.
- Fixed crash when changing anim file in animation editor. Fixes #60 

- Added hexadecimal values to animation list. Fixed status bar text formatting. Closes #62 
- Updated Serilog package to 2.10.0.