### PR TITLE
New tile view control and version 4.9.6

### DIFF
--- a/Ultima/Art.cs
+++ b/Ultima/Art.cs
@@ -37,16 +37,19 @@ namespace Ultima
 
         public static int GetMaxItemID()
         {
+            // High Seas
             if (GetIdxLength() >= 0x13FDC)
             {
-                return 0xFFFF;
+                return 0xFFDC;
             }
 
+            // Stygian Abyss
             if (GetIdxLength() == 0xC000)
             {
                 return 0x7FFF;
             }
 
+            // ML and older
             return 0x3FFF;
         }
 

--- a/UoFiddler.Controls/Forms/AnimationEditForm.cs
+++ b/UoFiddler.Controls/Forms/AnimationEditForm.cs
@@ -758,48 +758,7 @@ namespace UoFiddler.Controls.Forms
                                     bmp.SelectActiveFrame(dimension, 0);
                                     edit.GetGifPalette(bmp);
                                     progressBar1.Maximum = frameCount;
-                                    // Return an Image at a certain index
-                                    for (int index = 0; index < frameCount; index++)
-                                    {
-                                        bitBmp[index] = new Bitmap(bmp.Width, bmp.Height, PixelFormat.Format16bppArgb1555);
-                                        bmp.SelectActiveFrame(dimension, index);
-                                        bitBmp[index] = ConvertBmpAnim(bitBmp[index], (int)numericUpDownRed.Value,
-                                            (int)numericUpDownGreen.Value, (int)numericUpDownBlue.Value);
-                                        edit.AddFrame(bitBmp[index], bitBmp[index].Width/2);
-                                        TreeNode node = GetNode(_currentBody);
-                                        if (node != null)
-                                        {
-                                            node.ForeColor = Color.Black;
-                                            node.Nodes[_currentAction].ForeColor = Color.Black;
-                                        }
-
-                                        int i = edit.Frames.Count - 1;
-                                        var item = new ListViewItem(i.ToString(), 0)
-                                        {
-                                            Tag = i
-                                        };
-                                        listView1.Items.Add(item);
-                                        int width = listView1.TileSize.Width - 5;
-                                        if (bmp.Width > listView1.TileSize.Width)
-                                        {
-                                            width = bmp.Width;
-                                        }
-
-                                        int height = listView1.TileSize.Height - 5;
-                                        if (bmp.Height > listView1.TileSize.Height)
-                                        {
-                                            height = bmp.Height;
-                                        }
-
-                                        listView1.TileSize = new Size(width + 5, height + 5);
-                                        trackBar2.Maximum = i;
-                                        Options.ChangedUltimaClass["Animations"] = true;
-                                        if (progressBar1.Value < progressBar1.Maximum)
-                                        {
-                                            progressBar1.Value++;
-                                            progressBar1.Invalidate();
-                                        }
-                                    }
+                                    AddImageAtCertainIndex(frameCount, bitBmp, bmp, dimension, edit);
                                     progressBar1.Value = 0;
                                     progressBar1.Invalidate();
                                     SetPaletteBox();
@@ -857,6 +816,52 @@ namespace UoFiddler.Controls.Forms
             // Refresh List
             _currentDir = trackBarDirection.Value;
             AfterSelectTreeView(null, null);
+        }
+
+        private void AddImageAtCertainIndex(int frameCount, Bitmap[] bitBmp, Bitmap bmp, FrameDimension dimension, AnimIdx edit)
+        {
+            // Return an Image at a certain index
+            for (int index = 0; index < frameCount; index++)
+            {
+                bitBmp[index] = new Bitmap(bmp.Width, bmp.Height, PixelFormat.Format16bppArgb1555);
+                bmp.SelectActiveFrame(dimension, index);
+                bitBmp[index] = ConvertBmpAnim(bitBmp[index], (int) numericUpDownRed.Value,
+                    (int) numericUpDownGreen.Value, (int) numericUpDownBlue.Value);
+                edit.AddFrame(bitBmp[index], bitBmp[index].Width / 2);
+                TreeNode node = GetNode(_currentBody);
+                if (node != null)
+                {
+                    node.ForeColor = Color.Black;
+                    node.Nodes[_currentAction].ForeColor = Color.Black;
+                }
+
+                int i = edit.Frames.Count - 1;
+                var item = new ListViewItem(i.ToString(), 0)
+                {
+                    Tag = i
+                };
+                listView1.Items.Add(item);
+                int width = listView1.TileSize.Width - 5;
+                if (bmp.Width > listView1.TileSize.Width)
+                {
+                    width = bmp.Width;
+                }
+
+                int height = listView1.TileSize.Height - 5;
+                if (bmp.Height > listView1.TileSize.Height)
+                {
+                    height = bmp.Height;
+                }
+
+                listView1.TileSize = new Size(width + 5, height + 5);
+                trackBar2.Maximum = i;
+                Options.ChangedUltimaClass["Animations"] = true;
+                if (progressBar1.Value < progressBar1.Maximum)
+                {
+                    progressBar1.Value++;
+                    progressBar1.Invalidate();
+                }
+            }
         }
 
         private void OnClickExtractPalette(object sender, EventArgs e)
@@ -1323,50 +1328,7 @@ namespace UoFiddler.Controls.Forms
                         bmp.SelectActiveFrame(dimension, 0);
                         edit.GetGifPalette(bmp);
                         Bitmap[] bitBmp = new Bitmap[frameCount];
-                        // Return an Image at a certain index
-                        for (int index = 0; index < frameCount; index++)
-                        {
-                            bitBmp[index] = new Bitmap(bmp.Width, bmp.Height, PixelFormat.Format16bppArgb1555);
-                            bmp.SelectActiveFrame(dimension, index);
-                            bitBmp[index] = ConvertBmpAnim(bitBmp[index], (int) numericUpDownRed.Value,
-                                (int) numericUpDownGreen.Value, (int) numericUpDownBlue.Value);
-                            edit.AddFrame(bitBmp[index], bitBmp[index].Width/2);
-                            TreeNode node = GetNode(_currentBody);
-                            if (node != null)
-                            {
-                                node.ForeColor = Color.Black;
-                                node.Nodes[_currentAction].ForeColor = Color.Black;
-                            }
-
-                            int i = edit.Frames.Count - 1;
-                            var item = new ListViewItem(i.ToString(), 0)
-                            {
-                                Tag = i
-                            };
-                            listView1.Items.Add(item);
-
-                            int width = listView1.TileSize.Width - 5;
-                            if (bmp.Width > listView1.TileSize.Width)
-                            {
-                                width = bmp.Width;
-                            }
-
-                            int height = listView1.TileSize.Height - 5;
-                            if (bmp.Height > listView1.TileSize.Height)
-                            {
-                                height = bmp.Height;
-                            }
-
-                            listView1.TileSize = new Size(width + 5, height + 5);
-                            trackBar2.Maximum = i;
-                            Options.ChangedUltimaClass["Animations"] = true;
-                            if (progressBar1.Value < progressBar1.Maximum)
-                            {
-                                progressBar1.Value++;
-                                progressBar1.Invalidate();
-                            }
-                        }
-
+                        AddImageAtCertainIndex(frameCount, bitBmp, bmp, dimension, edit);
                         progressBar1.Value = 0;
                         progressBar1.Invalidate();
                         SetPaletteBox();

--- a/UoFiddler.Controls/Forms/AnimationListNewEntriesForm.cs
+++ b/UoFiddler.Controls/Forms/AnimationListNewEntriesForm.cs
@@ -11,6 +11,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
 using System.Windows.Forms;
@@ -132,7 +133,6 @@ namespace UoFiddler.Controls.Forms
 
             MobTypes();
 
-            TreeNode node;
             foreach (var key in BodyTable.Entries) //body.def
             {
                 BodyTableEntry entry = key.Value;
@@ -146,7 +146,7 @@ namespace UoFiddler.Controls.Forms
                     continue;
                 }
 
-                node = new TreeNode(entry.NewId.ToString())
+                TreeNode node = new TreeNode(entry.NewId.ToString())
                 {
                     Tag = entry.NewId,
                     ToolTipText = $"Found in body.def {Animations.GetFileName(entry.NewId)}"
@@ -158,125 +158,56 @@ namespace UoFiddler.Controls.Forms
 
             if (BodyConverter.Table1 != null)
             {
-                foreach (int entry in BodyConverter.Table1)  // bodyconv.def
-                {
-                    if (entry == -1)
-                    {
-                        continue;
-                    }
-
-                    if (AlreadyFound(entry))
-                    {
-                        continue;
-                    }
-
-                    if (_form.IsAlreadyDefined(entry))
-                    {
-                        continue;
-                    }
-
-                    node = new TreeNode(entry.ToString())
-                    {
-                        ToolTipText = $"Found in bodyconv.def {Animations.GetFileName(entry)}",
-                        Tag = entry
-                    };
-                    node.Tag = new[] { entry, 0 };
-                    tvAnimationList.Nodes.Add(node);
-                    SetActionType(node, entry, 0);
-                }
+                ProcessBodyConverterTable(BodyConverter.Table1);
             }
 
             if (BodyConverter.Table2 != null)
             {
-                foreach (int entry in BodyConverter.Table2)
-                {
-                    if (entry == -1)
-                    {
-                        continue;
-                    }
-
-                    if (AlreadyFound(entry))
-                    {
-                        continue;
-                    }
-
-                    if (_form.IsAlreadyDefined(entry))
-                    {
-                        continue;
-                    }
-
-                    node = new TreeNode(entry.ToString())
-                    {
-                        ToolTipText = $"Found in bodyconv.def {Animations.GetFileName(entry)}",
-                        Tag = entry
-                    };
-                    node.Tag = new[] { entry, 0 };
-                    tvAnimationList.Nodes.Add(node);
-                    SetActionType(node, entry, 0);
-                }
+                ProcessBodyConverterTable(BodyConverter.Table2);
             }
 
             if (BodyConverter.Table3 != null)
             {
-                foreach (int entry in BodyConverter.Table3)
-                {
-                    if (entry == -1)
-                    {
-                        continue;
-                    }
-
-                    if (AlreadyFound(entry))
-                    {
-                        continue;
-                    }
-
-                    if (_form.IsAlreadyDefined(entry))
-                    {
-                        continue;
-                    }
-
-                    node = new TreeNode(entry.ToString())
-                    {
-                        ToolTipText = $"Found in bodyconv.def {Animations.GetFileName(entry)}",
-                        Tag = entry
-                    };
-                    node.Tag = new[] { entry, 0 };
-                    tvAnimationList.Nodes.Add(node);
-                    SetActionType(node, entry, 0);
-                }
+                ProcessBodyConverterTable(BodyConverter.Table3);
             }
 
             if (BodyConverter.Table4 != null)
             {
-                foreach (int entry in BodyConverter.Table4)
-                {
-                    if (entry == -1)
-                    {
-                        continue;
-                    }
-
-                    if (AlreadyFound(entry))
-                    {
-                        continue;
-                    }
-
-                    if (_form.IsAlreadyDefined(entry))
-                    {
-                        continue;
-                    }
-
-                    node = new TreeNode(entry.ToString())
-                    {
-                        ToolTipText = $"Found in bodyconv.def {Animations.GetFileName(entry)}",
-                        Tag = entry
-                    };
-                    node.Tag = new[] { entry, 0 };
-                    tvAnimationList.Nodes.Add(node);
-                    SetActionType(node, entry, 0);
-                }
+                ProcessBodyConverterTable(BodyConverter.Table4);
             }
 
             tvAnimationList.EndUpdate();
+        }
+
+        private void ProcessBodyConverterTable(IEnumerable<int> table)
+        {
+            // bodyconv.def
+            foreach (int entry in table)
+            {
+                if (entry == -1)
+                {
+                    continue;
+                }
+
+                if (AlreadyFound(entry))
+                {
+                    continue;
+                }
+
+                if (_form.IsAlreadyDefined(entry))
+                {
+                    continue;
+                }
+
+                TreeNode node = new TreeNode(entry.ToString())
+                {
+                    ToolTipText = $"Found in bodyconv.def {Animations.GetFileName(entry)}",
+                    Tag = entry
+                };
+                node.Tag = new[] { entry, 0 };
+                tvAnimationList.Nodes.Add(node);
+                SetActionType(node, entry, 0);
+            }
         }
 
         private bool AlreadyFound(int graphic)
@@ -315,27 +246,34 @@ namespace UoFiddler.Controls.Forms
                     try
                     {
                         string[] split = line.Split('\t');
-                        if (int.TryParse(split[0], out int graphic))
+                        if (int.TryParse(split[0], out int graphic) && !AlreadyFound(graphic) && !_form.IsAlreadyDefined(graphic))
                         {
-                            if (!AlreadyFound(graphic) && !_form.IsAlreadyDefined(graphic))
+                            TreeNode node = new TreeNode(graphic.ToString())
                             {
-                                TreeNode node = new TreeNode(graphic.ToString())
-                                {
-                                    ToolTipText = $"Found in mobtype.txt {Animations.GetFileName(graphic)}"
-                                };
-                                int type = 0;
-                                switch (split[1])
-                                {
-                                    case "MONSTER": type = 0; break;
-                                    case "SEA_MONSTER": type = 1; break;
-                                    case "ANIMAL": type = 2; break;
-                                    case "HUMAN": type = 3; break;
-                                    case "EQUIPMENT": type = 3; break;
-                                }
-                                node.Tag = new[] { graphic, type };
-                                tvAnimationList.Nodes.Add(node);
-                                SetActionType(node, graphic, type);
+                                ToolTipText = $"Found in mobtype.txt {Animations.GetFileName(graphic)}"
+                            };
+
+                            int type = 0;
+                            switch (split[1])
+                            {
+                                case "MONSTER":
+                                    type = 0;
+                                    break;
+                                case "SEA_MONSTER":
+                                    type = 1;
+                                    break;
+                                case "ANIMAL":
+                                    type = 2;
+                                    break;
+                                case "HUMAN":
+                                case "EQUIPMENT":
+                                    type = 3;
+                                    break;
                             }
+
+                            node.Tag = new[] { graphic, type };
+                            tvAnimationList.Nodes.Add(node);
+                            SetActionType(node, graphic, type);
                         }
                     }
                     catch
@@ -349,7 +287,7 @@ namespace UoFiddler.Controls.Forms
         private void SetActionType(TreeNode parent, int graphic, int type)
         {
             parent.Nodes.Clear();
-            if (type == 4) // Equipment == human
+            if (type == 4) // Equipment == Human
             {
                 type = 3;
             }
@@ -422,6 +360,7 @@ namespace UoFiddler.Controls.Forms
                     X = (pictureBox1.Width - frames[0].Bitmap.Width) / 2,
                     Y = (pictureBox1.Height - frames[0].Bitmap.Height) / 2
                 };
+
                 e.Graphics.DrawImage(frames[0].Bitmap, loc);
             }
         }
@@ -442,7 +381,10 @@ namespace UoFiddler.Controls.Forms
             if (node.Parent != null)
             {
                 node = node.Parent;
-            } ((int[])node.Tag)[1] = ComboBoxActionType.SelectedIndex;
+            }
+
+            ((int[])node.Tag)[1] = ComboBoxActionType.SelectedIndex;
+
             SetActionType(node, ((int[])node.Tag)[0], ComboBoxActionType.SelectedIndex);
         }
 
@@ -492,14 +434,13 @@ namespace UoFiddler.Controls.Forms
             {
                 return 0;
             }
-            else if (ix[0] < iy[0])
+
+            if (ix[0] < iy[0])
             {
                 return -1;
             }
-            else
-            {
-                return 1;
-            }
+
+            return 1;
         }
     }
 }

--- a/UoFiddler.Controls/Forms/ProgressBarDialog.Designer.cs
+++ b/UoFiddler.Controls/Forms/ProgressBarDialog.Designer.cs
@@ -28,22 +28,22 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.progressBar1 = new System.Windows.Forms.ProgressBar();
+            this.progressBar = new System.Windows.Forms.ProgressBar();
             this.SuspendLayout();
             // 
             // progressBar1
             // 
-            this.progressBar1.Location = new System.Drawing.Point(12, 12);
-            this.progressBar1.Name = "progressBar1";
-            this.progressBar1.Size = new System.Drawing.Size(260, 23);
-            this.progressBar1.TabIndex = 0;
+            this.progressBar.Location = new System.Drawing.Point(12, 12);
+            this.progressBar.Name = "progressBar";
+            this.progressBar.Size = new System.Drawing.Size(260, 23);
+            this.progressBar.TabIndex = 0;
             // 
             // ProgressBar
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(286, 50);
-            this.Controls.Add(this.progressBar1);
+            this.Controls.Add(this.progressBar);
             this.DoubleBuffered = true;
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
             this.Name = "ProgressBarDialog";
@@ -53,7 +53,7 @@
 
         }
 
-        private System.Windows.Forms.ProgressBar progressBar1;
+        private System.Windows.Forms.ProgressBar progressBar;
 
         #endregion
     }

--- a/UoFiddler.Controls/Forms/ProgressBarDialog.cs
+++ b/UoFiddler.Controls/Forms/ProgressBarDialog.cs
@@ -18,16 +18,18 @@ namespace UoFiddler.Controls.Forms
         public ProgressBarDialog()
         {
             InitializeComponent();
+
+            SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.OptimizedDoubleBuffer | ControlStyles.UserPaint, true);
         }
 
         public ProgressBarDialog(int max, string desc, bool useFileSaveEvent = true)
         {
             InitializeComponent();
             Text = desc;
-            progressBar1.Maximum = max;
-            progressBar1.Minimum = 0;
-            progressBar1.Value = 0;
-            progressBar1.Step = 1;
+            progressBar.Maximum = max;
+            progressBar.Minimum = 0;
+            progressBar.Value = 0;
+            progressBar.Step = 1;
             if (useFileSaveEvent)
             {
                 Ultima.Files.FileSaveEvent += OnChangeEvent;
@@ -42,7 +44,7 @@ namespace UoFiddler.Controls.Forms
 
         private void OnChangeEvent()
         {
-            progressBar1.PerformStep();
+            progressBar.PerformStep();
         }
     }
 }

--- a/UoFiddler.Controls/Plugin/Interfaces/IPluginHost.cs
+++ b/UoFiddler.Controls/Plugin/Interfaces/IPluginHost.cs
@@ -11,6 +11,7 @@
 
 using System.Windows.Forms;
 using UoFiddler.Controls.UserControls;
+using UoFiddler.Controls.UserControls.TileView;
 
 namespace UoFiddler.Controls.Plugin.Interfaces
 {
@@ -29,6 +30,12 @@ namespace UoFiddler.Controls.Plugin.Interfaces
         ItemShowAlternativeControl GetItemShowAltControl();
 
         /// <summary>
+        /// Gets the TileView of ItemShowAlternative
+        /// </summary>
+        /// <returns></returns>
+        TileViewControl GetItemShowAltTileView();
+
+        /// <summary>
         /// Gets the current selected graphic in ItemShow
         /// </summary>
         /// <returns>Graphic or -1 if none selected</returns>
@@ -45,11 +52,5 @@ namespace UoFiddler.Controls.Plugin.Interfaces
         /// </summary>
         /// <returns></returns>
         ListView GetItemShowListView();
-
-        /// <summary>
-        /// Gets the PictureBox of ItemShowAlt
-        /// </summary>
-        /// <returns></returns>
-        PictureBox GetItemShowAltPictureBox();
     }
 }

--- a/UoFiddler.Controls/Plugin/PluginServices.cs
+++ b/UoFiddler.Controls/Plugin/PluginServices.cs
@@ -17,6 +17,7 @@ using UoFiddler.Controls.Classes;
 using UoFiddler.Controls.Plugin.Interfaces;
 using UoFiddler.Controls.Plugin.Types;
 using UoFiddler.Controls.UserControls;
+using UoFiddler.Controls.UserControls.TileView;
 
 namespace UoFiddler.Controls.Plugin
 {
@@ -137,19 +138,19 @@ namespace UoFiddler.Controls.Plugin
             return ItemShowControl.ItemListView;
         }
 
+        public TileViewControl GetItemShowAltTileView()
+        {
+            return ItemShowAlternativeControl.TileView;
+        }
+
         public ItemShowAlternativeControl GetItemShowAltControl()
         {
             return ItemShowAlternativeControl.RefMarker;
         }
 
-        public PictureBox GetItemShowAltPictureBox()
-        {
-            return ItemShowAlternativeControl.ItemPictureBox;
-        }
-
         public int GetSelectedItemShowAlternative()
         {
-            return ItemShowAlternativeControl.RefMarker.Selected;
+            return ItemShowAlternativeControl.RefMarker.SelectedGraphicId;
         }
     }
 }

--- a/UoFiddler.Controls/UserControls/AnimDataControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/AnimDataControl.Designer.cs
@@ -50,21 +50,21 @@ namespace UoFiddler.Controls.UserControls
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.button1 = new System.Windows.Forms.Button();
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
+            this.groupBox3 = new System.Windows.Forms.GroupBox();
+            this.button6 = new System.Windows.Forms.Button();
             this.groupBox4 = new System.Windows.Forms.GroupBox();
+            this.button5 = new System.Windows.Forms.Button();
+            this.button2 = new System.Windows.Forms.Button();
             this.button4 = new System.Windows.Forms.Button();
+            this.checkBoxRelative = new System.Windows.Forms.CheckBox();
             this.button3 = new System.Windows.Forms.Button();
+            this.textBoxAddFrame = new System.Windows.Forms.TextBox();
             this.treeViewFrames = new System.Windows.Forms.TreeView();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.label2 = new System.Windows.Forms.Label();
             this.numericUpDownFrameDelay = new System.Windows.Forms.NumericUpDown();
             this.label1 = new System.Windows.Forms.Label();
             this.numericUpDownStartDelay = new System.Windows.Forms.NumericUpDown();
-            this.groupBox3 = new System.Windows.Forms.GroupBox();
-            this.button6 = new System.Windows.Forms.Button();
-            this.textBoxAddFrame = new System.Windows.Forms.TextBox();
-            this.checkBoxRelative = new System.Windows.Forms.CheckBox();
-            this.button2 = new System.Windows.Forms.Button();
-            this.button5 = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -76,11 +76,11 @@ namespace UoFiddler.Controls.UserControls
             this.splitContainer2.SuspendLayout();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
+            this.groupBox3.SuspendLayout();
             this.groupBox4.SuspendLayout();
             this.groupBox2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownFrameDelay)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownStartDelay)).BeginInit();
-            this.groupBox3.SuspendLayout();
             this.SuspendLayout();
             // 
             // splitContainer1
@@ -131,7 +131,6 @@ namespace UoFiddler.Controls.UserControls
             // 
             // AddTextBox
             // 
-            this.AddTextBox.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.AddTextBox.Name = "AddTextBox";
             this.AddTextBox.Size = new System.Drawing.Size(100, 23);
             this.AddTextBox.KeyDown += new System.Windows.Forms.KeyEventHandler(this.OnKeyDownAdd);
@@ -197,6 +196,27 @@ namespace UoFiddler.Controls.UserControls
             this.pictureBox1.TabIndex = 0;
             this.pictureBox1.TabStop = false;
             // 
+            // groupBox3
+            // 
+            this.groupBox3.Controls.Add(this.button6);
+            this.groupBox3.Dock = System.Windows.Forms.DockStyle.Top;
+            this.groupBox3.Location = new System.Drawing.Point(0, 449);
+            this.groupBox3.Name = "groupBox3";
+            this.groupBox3.Size = new System.Drawing.Size(227, 53);
+            this.groupBox3.TabIndex = 6;
+            this.groupBox3.TabStop = false;
+            // 
+            // button6
+            // 
+            this.button6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.button6.Location = new System.Drawing.Point(146, 19);
+            this.button6.Name = "button6";
+            this.button6.Size = new System.Drawing.Size(75, 23);
+            this.button6.TabIndex = 6;
+            this.button6.Text = "Save";
+            this.button6.UseVisualStyleBackColor = true;
+            this.button6.Click += new System.EventHandler(this.OnClickSave);
+            // 
             // groupBox4
             // 
             this.groupBox4.Controls.Add(this.button5);
@@ -214,6 +234,26 @@ namespace UoFiddler.Controls.UserControls
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Frames";
             // 
+            // button5
+            // 
+            this.button5.Location = new System.Drawing.Point(93, 334);
+            this.button5.Name = "button5";
+            this.button5.Size = new System.Drawing.Size(75, 23);
+            this.button5.TabIndex = 4;
+            this.button5.Text = "Remove";
+            this.button5.UseVisualStyleBackColor = true;
+            this.button5.Click += new System.EventHandler(this.OnClickRemove);
+            // 
+            // button2
+            // 
+            this.button2.Location = new System.Drawing.Point(12, 334);
+            this.button2.Name = "button2";
+            this.button2.Size = new System.Drawing.Size(75, 23);
+            this.button2.TabIndex = 2;
+            this.button2.Text = "Add";
+            this.button2.UseVisualStyleBackColor = true;
+            this.button2.Click += new System.EventHandler(this.OnClickAdd);
+            // 
             // button4
             // 
             this.button4.Font = new System.Drawing.Font("Microsoft Sans Serif", 7F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -225,6 +265,17 @@ namespace UoFiddler.Controls.UserControls
             this.button4.UseVisualStyleBackColor = true;
             this.button4.Click += new System.EventHandler(this.OnClickFrameDown);
             // 
+            // checkBoxRelative
+            // 
+            this.checkBoxRelative.AutoSize = true;
+            this.checkBoxRelative.Location = new System.Drawing.Point(93, 310);
+            this.checkBoxRelative.Name = "checkBoxRelative";
+            this.checkBoxRelative.Size = new System.Drawing.Size(65, 17);
+            this.checkBoxRelative.TabIndex = 1;
+            this.checkBoxRelative.Text = "Relative";
+            this.checkBoxRelative.UseVisualStyleBackColor = true;
+            this.checkBoxRelative.CheckedChanged += new System.EventHandler(this.OnCheckChange);
+            // 
             // button3
             // 
             this.button3.Font = new System.Drawing.Font("Microsoft Sans Serif", 7F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -235,6 +286,14 @@ namespace UoFiddler.Controls.UserControls
             this.button3.Text = "▲";
             this.button3.UseVisualStyleBackColor = true;
             this.button3.Click += new System.EventHandler(this.OnClickFrameUp);
+            // 
+            // textBoxAddFrame
+            // 
+            this.textBoxAddFrame.Location = new System.Drawing.Point(12, 308);
+            this.textBoxAddFrame.Name = "textBoxAddFrame";
+            this.textBoxAddFrame.Size = new System.Drawing.Size(72, 20);
+            this.textBoxAddFrame.TabIndex = 0;
+            this.textBoxAddFrame.TextChanged += new System.EventHandler(this.OnTextChanged);
             // 
             // treeViewFrames
             // 
@@ -305,65 +364,6 @@ namespace UoFiddler.Controls.UserControls
             this.numericUpDownStartDelay.TabIndex = 0;
             this.numericUpDownStartDelay.ValueChanged += new System.EventHandler(this.OnValueChangedStartDelay);
             // 
-            // groupBox3
-            // 
-            this.groupBox3.Controls.Add(this.button6);
-            this.groupBox3.Dock = System.Windows.Forms.DockStyle.Top;
-            this.groupBox3.Location = new System.Drawing.Point(0, 449);
-            this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(227, 53);
-            this.groupBox3.TabIndex = 6;
-            this.groupBox3.TabStop = false;
-            // 
-            // button6
-            // 
-            this.button6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button6.Location = new System.Drawing.Point(146, 19);
-            this.button6.Name = "button6";
-            this.button6.Size = new System.Drawing.Size(75, 23);
-            this.button6.TabIndex = 6;
-            this.button6.Text = "Save";
-            this.button6.UseVisualStyleBackColor = true;
-            // 
-            // textBoxAddFrame
-            // 
-            this.textBoxAddFrame.Location = new System.Drawing.Point(12, 308);
-            this.textBoxAddFrame.Name = "textBoxAddFrame";
-            this.textBoxAddFrame.Size = new System.Drawing.Size(72, 20);
-            this.textBoxAddFrame.TabIndex = 0;
-            this.textBoxAddFrame.TextChanged += new System.EventHandler(this.OnTextChanged);
-            // 
-            // checkBoxRelative
-            // 
-            this.checkBoxRelative.AutoSize = true;
-            this.checkBoxRelative.Location = new System.Drawing.Point(93, 310);
-            this.checkBoxRelative.Name = "checkBoxRelative";
-            this.checkBoxRelative.Size = new System.Drawing.Size(65, 17);
-            this.checkBoxRelative.TabIndex = 1;
-            this.checkBoxRelative.Text = "Relative";
-            this.checkBoxRelative.UseVisualStyleBackColor = true;
-            this.checkBoxRelative.CheckedChanged += new System.EventHandler(this.OnCheckChange);
-            // 
-            // button2
-            // 
-            this.button2.Location = new System.Drawing.Point(12, 334);
-            this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(75, 23);
-            this.button2.TabIndex = 2;
-            this.button2.Text = "Add";
-            this.button2.UseVisualStyleBackColor = true;
-            this.button2.Click += new System.EventHandler(this.OnClickAdd);
-            // 
-            // button5
-            // 
-            this.button5.Location = new System.Drawing.Point(93, 334);
-            this.button5.Name = "button5";
-            this.button5.Size = new System.Drawing.Size(75, 23);
-            this.button5.TabIndex = 4;
-            this.button5.Text = "Remove";
-            this.button5.UseVisualStyleBackColor = true;
-            this.button5.Click += new System.EventHandler(this.OnClickRemove);
-            // 
             // AnimDataControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -384,13 +384,13 @@ namespace UoFiddler.Controls.UserControls
             this.splitContainer2.ResumeLayout(false);
             this.groupBox1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).EndInit();
+            this.groupBox3.ResumeLayout(false);
             this.groupBox4.ResumeLayout(false);
             this.groupBox4.PerformLayout();
             this.groupBox2.ResumeLayout(false);
             this.groupBox2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownFrameDelay)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownStartDelay)).EndInit();
-            this.groupBox3.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }

--- a/UoFiddler.Controls/UserControls/FontsControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/FontsControl.Designer.cs
@@ -41,7 +41,6 @@ namespace UoFiddler.Controls.UserControls
         {
             this.components = new System.ComponentModel.Container();
             this.treeView = new System.Windows.Forms.TreeView();
-            this.listView1 = new System.Windows.Forms.ListView();
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.writeTextToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
@@ -51,6 +50,7 @@ namespace UoFiddler.Controls.UserControls
             this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
+            this.FontsTileView = new UoFiddler.Controls.UserControls.TileView.TileViewControl();
             this.contextMenuStrip1.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             this.SuspendLayout();
@@ -64,26 +64,6 @@ namespace UoFiddler.Controls.UserControls
             this.treeView.Size = new System.Drawing.Size(121, 328);
             this.treeView.TabIndex = 0;
             this.treeView.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.OnSelect);
-            // 
-            // listView1
-            // 
-            this.listView1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.listView1.ContextMenuStrip = this.contextMenuStrip1;
-            this.listView1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.listView1.HideSelection = false;
-            this.listView1.Location = new System.Drawing.Point(121, 0);
-            this.listView1.Margin = new System.Windows.Forms.Padding(2);
-            this.listView1.MultiSelect = false;
-            this.listView1.Name = "listView1";
-            this.listView1.OwnerDraw = true;
-            this.listView1.ShowGroups = false;
-            this.listView1.Size = new System.Drawing.Size(502, 306);
-            this.listView1.TabIndex = 4;
-            this.listView1.TileSize = new System.Drawing.Size(46, 46);
-            this.listView1.UseCompatibleStateImageBehavior = false;
-            this.listView1.View = System.Windows.Forms.View.Tile;
-            this.listView1.DrawItem += new System.Windows.Forms.DrawListViewItemEventHandler(this.DrawItem);
-            this.listView1.SelectedIndexChanged += new System.EventHandler(this.OnSelectChar);
             // 
             // contextMenuStrip1
             // 
@@ -153,11 +133,35 @@ namespace UoFiddler.Controls.UserControls
             this.toolStripStatusLabel1.Size = new System.Drawing.Size(24, 17);
             this.toolStripStatusLabel1.Text = " : ()";
             // 
-            // Fonts
+            // FontsTileView
+            // 
+            this.FontsTileView.AutoScroll = true;
+            this.FontsTileView.AutoScrollMinSize = new System.Drawing.Size(0, 34);
+            this.FontsTileView.BackColor = System.Drawing.Color.White;
+            this.FontsTileView.ContextMenuStrip = this.contextMenuStrip1;
+            this.FontsTileView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.FontsTileView.FocusIndex = -1;
+            this.FontsTileView.Location = new System.Drawing.Point(121, 0);
+            this.FontsTileView.MultiSelect = false;
+            this.FontsTileView.Name = "FontsTileView";
+            this.FontsTileView.Size = new System.Drawing.Size(502, 306);
+            this.FontsTileView.TabIndex = 6;
+            this.FontsTileView.TileBackgroundColor = System.Drawing.SystemColors.Window;
+            this.FontsTileView.TileBorderColor = System.Drawing.Color.Gray;
+            this.FontsTileView.TileBorderWidth = 1F;
+            this.FontsTileView.TileHighlightColor = System.Drawing.SystemColors.Highlight;
+            this.FontsTileView.TileMargin = new System.Windows.Forms.Padding(2, 2, 0, 0);
+            this.FontsTileView.TilePadding = new System.Windows.Forms.Padding(0);
+            this.FontsTileView.TileSize = new System.Drawing.Size(30, 30);
+            this.FontsTileView.VirtualListSize = 1;
+            this.FontsTileView.ItemSelectionChanged += new System.EventHandler<System.Windows.Forms.ListViewItemSelectionChangedEventArgs>(this.FontsTileView_ItemSelectionChanged);
+            this.FontsTileView.DrawItem += new System.EventHandler<UoFiddler.Controls.UserControls.TileView.TileViewControl.DrawTileListItemEventArgs>(this.FontsTileView_DrawItem);
+            // 
+            // FontsControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.listView1);
+            this.Controls.Add(this.FontsTileView);
             this.Controls.Add(this.statusStrip1);
             this.Controls.Add(this.treeView);
             this.DoubleBuffered = true;
@@ -175,7 +179,6 @@ namespace UoFiddler.Controls.UserControls
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
         private System.Windows.Forms.ToolStripMenuItem extractCharacterToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem importCharacterToolStripMenuItem;
-        private System.Windows.Forms.ListView listView1;
         private System.Windows.Forms.ToolStripMenuItem saveToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem setOffsetsToolStripMenuItem;
         private System.Windows.Forms.StatusStrip statusStrip1;
@@ -185,5 +188,7 @@ namespace UoFiddler.Controls.UserControls
         private System.Windows.Forms.ToolStripMenuItem writeTextToolStripMenuItem;
 
         #endregion
+
+        private TileView.TileViewControl FontsTileView;
     }
 }

--- a/UoFiddler.Controls/UserControls/FontsControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/FontsControl.Designer.cs
@@ -40,7 +40,6 @@ namespace UoFiddler.Controls.UserControls
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            this.treeView = new System.Windows.Forms.TreeView();
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.writeTextToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
@@ -48,22 +47,24 @@ namespace UoFiddler.Controls.UserControls
             this.extractCharacterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.importCharacterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
+            this.splitContainer2 = new System.Windows.Forms.SplitContainer();
+            this.treeView = new System.Windows.Forms.TreeView();
+            this.LoadUnicodeFontsCheckBox = new System.Windows.Forms.CheckBox();
+            this.FontsTileView = new UoFiddler.Controls.UserControls.TileView.TileViewControl();
             this.statusStrip1 = new System.Windows.Forms.StatusStrip();
             this.toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
-            this.FontsTileView = new UoFiddler.Controls.UserControls.TileView.TileViewControl();
             this.contextMenuStrip1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
+            this.splitContainer1.Panel1.SuspendLayout();
+            this.splitContainer1.Panel2.SuspendLayout();
+            this.splitContainer1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).BeginInit();
+            this.splitContainer2.Panel1.SuspendLayout();
+            this.splitContainer2.Panel2.SuspendLayout();
+            this.splitContainer2.SuspendLayout();
             this.statusStrip1.SuspendLayout();
             this.SuspendLayout();
-            // 
-            // treeView
-            // 
-            this.treeView.Dock = System.Windows.Forms.DockStyle.Left;
-            this.treeView.HideSelection = false;
-            this.treeView.Location = new System.Drawing.Point(0, 0);
-            this.treeView.Name = "treeView";
-            this.treeView.Size = new System.Drawing.Size(121, 328);
-            this.treeView.TabIndex = 0;
-            this.treeView.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.OnSelect);
             // 
             // contextMenuStrip1
             // 
@@ -117,21 +118,64 @@ namespace UoFiddler.Controls.UserControls
             this.saveToolStripMenuItem.Text = "Save";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.OnClickSave);
             // 
-            // statusStrip1
+            // splitContainer1
             // 
-            this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripStatusLabel1});
-            this.statusStrip1.Location = new System.Drawing.Point(121, 306);
-            this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Size = new System.Drawing.Size(502, 22);
-            this.statusStrip1.TabIndex = 5;
-            this.statusStrip1.Text = "statusStrip1";
+            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel1;
+            this.splitContainer1.IsSplitterFixed = true;
+            this.splitContainer1.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer1.Name = "splitContainer1";
             // 
-            // toolStripStatusLabel1
+            // splitContainer1.Panel1
             // 
-            this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
-            this.toolStripStatusLabel1.Size = new System.Drawing.Size(24, 17);
-            this.toolStripStatusLabel1.Text = " : ()";
+            this.splitContainer1.Panel1.Controls.Add(this.splitContainer2);
+            // 
+            // splitContainer1.Panel2
+            // 
+            this.splitContainer1.Panel2.Controls.Add(this.FontsTileView);
+            this.splitContainer1.Panel2.Controls.Add(this.statusStrip1);
+            this.splitContainer1.Size = new System.Drawing.Size(623, 328);
+            this.splitContainer1.SplitterDistance = 150;
+            this.splitContainer1.TabIndex = 1;
+            // 
+            // splitContainer2
+            // 
+            this.splitContainer2.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.splitContainer2.Location = new System.Drawing.Point(0, 0);
+            this.splitContainer2.Name = "splitContainer2";
+            this.splitContainer2.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainer2.Panel1
+            // 
+            this.splitContainer2.Panel1.Controls.Add(this.treeView);
+            // 
+            // splitContainer2.Panel2
+            // 
+            this.splitContainer2.Panel2.Controls.Add(this.LoadUnicodeFontsCheckBox);
+            this.splitContainer2.Size = new System.Drawing.Size(150, 328);
+            this.splitContainer2.SplitterDistance = 280;
+            this.splitContainer2.TabIndex = 0;
+            // 
+            // treeView
+            // 
+            this.treeView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.treeView.HideSelection = false;
+            this.treeView.Location = new System.Drawing.Point(0, 0);
+            this.treeView.Name = "treeView";
+            this.treeView.Size = new System.Drawing.Size(150, 280);
+            this.treeView.TabIndex = 2;
+            this.treeView.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.OnSelect);
+            // 
+            // LoadUnicodeFontsCheckBox
+            // 
+            this.LoadUnicodeFontsCheckBox.AutoSize = true;
+            this.LoadUnicodeFontsCheckBox.Location = new System.Drawing.Point(15, 14);
+            this.LoadUnicodeFontsCheckBox.Name = "LoadUnicodeFontsCheckBox";
+            this.LoadUnicodeFontsCheckBox.Size = new System.Drawing.Size(122, 17);
+            this.LoadUnicodeFontsCheckBox.TabIndex = 0;
+            this.LoadUnicodeFontsCheckBox.Text = "Load Unicode Fonts";
+            this.LoadUnicodeFontsCheckBox.UseVisualStyleBackColor = true;
+            this.LoadUnicodeFontsCheckBox.CheckedChanged += new System.EventHandler(this.LoadUnicodeFontsCheckBox_CheckedChanged);
             // 
             // FontsTileView
             // 
@@ -141,11 +185,11 @@ namespace UoFiddler.Controls.UserControls
             this.FontsTileView.ContextMenuStrip = this.contextMenuStrip1;
             this.FontsTileView.Dock = System.Windows.Forms.DockStyle.Fill;
             this.FontsTileView.FocusIndex = -1;
-            this.FontsTileView.Location = new System.Drawing.Point(121, 0);
+            this.FontsTileView.Location = new System.Drawing.Point(0, 0);
             this.FontsTileView.MultiSelect = false;
             this.FontsTileView.Name = "FontsTileView";
-            this.FontsTileView.Size = new System.Drawing.Size(502, 306);
-            this.FontsTileView.TabIndex = 6;
+            this.FontsTileView.Size = new System.Drawing.Size(469, 306);
+            this.FontsTileView.TabIndex = 8;
             this.FontsTileView.TileBackgroundColor = System.Drawing.SystemColors.Window;
             this.FontsTileView.TileBorderColor = System.Drawing.Color.Gray;
             this.FontsTileView.TileBorderWidth = 1F;
@@ -157,22 +201,46 @@ namespace UoFiddler.Controls.UserControls
             this.FontsTileView.ItemSelectionChanged += new System.EventHandler<System.Windows.Forms.ListViewItemSelectionChangedEventArgs>(this.FontsTileView_ItemSelectionChanged);
             this.FontsTileView.DrawItem += new System.EventHandler<UoFiddler.Controls.UserControls.TileView.TileViewControl.DrawTileListItemEventArgs>(this.FontsTileView_DrawItem);
             // 
+            // statusStrip1
+            // 
+            this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.toolStripStatusLabel1});
+            this.statusStrip1.Location = new System.Drawing.Point(0, 306);
+            this.statusStrip1.Name = "statusStrip1";
+            this.statusStrip1.Size = new System.Drawing.Size(469, 22);
+            this.statusStrip1.TabIndex = 7;
+            this.statusStrip1.Text = "statusStrip1";
+            // 
+            // toolStripStatusLabel1
+            // 
+            this.toolStripStatusLabel1.Name = "toolStripStatusLabel1";
+            this.toolStripStatusLabel1.Size = new System.Drawing.Size(87, 17);
+            this.toolStripStatusLabel1.Text = "<no selection>";
+            // 
             // FontsControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.FontsTileView);
-            this.Controls.Add(this.statusStrip1);
-            this.Controls.Add(this.treeView);
+            this.Controls.Add(this.splitContainer1);
             this.DoubleBuffered = true;
             this.Name = "FontsControl";
             this.Size = new System.Drawing.Size(623, 328);
             this.Load += new System.EventHandler(this.OnLoad);
+            this.Resize += new System.EventHandler(this.FontsControl_Resize);
             this.contextMenuStrip1.ResumeLayout(false);
+            this.splitContainer1.Panel1.ResumeLayout(false);
+            this.splitContainer1.Panel2.ResumeLayout(false);
+            this.splitContainer1.Panel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
+            this.splitContainer1.ResumeLayout(false);
+            this.splitContainer2.Panel1.ResumeLayout(false);
+            this.splitContainer2.Panel2.ResumeLayout(false);
+            this.splitContainer2.Panel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).EndInit();
+            this.splitContainer2.ResumeLayout(false);
             this.statusStrip1.ResumeLayout(false);
             this.statusStrip1.PerformLayout();
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
@@ -181,14 +249,17 @@ namespace UoFiddler.Controls.UserControls
         private System.Windows.Forms.ToolStripMenuItem importCharacterToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem saveToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem setOffsetsToolStripMenuItem;
-        private System.Windows.Forms.StatusStrip statusStrip1;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
-        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel1;
-        private System.Windows.Forms.TreeView treeView;
         private System.Windows.Forms.ToolStripMenuItem writeTextToolStripMenuItem;
 
         #endregion
 
+        private System.Windows.Forms.SplitContainer splitContainer1;
         private TileView.TileViewControl FontsTileView;
+        private System.Windows.Forms.SplitContainer splitContainer2;
+        private System.Windows.Forms.TreeView treeView;
+        private System.Windows.Forms.CheckBox LoadUnicodeFontsCheckBox;
+        private System.Windows.Forms.StatusStrip statusStrip1;
+        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel1;
     }
 }

--- a/UoFiddler.Controls/UserControls/FontsControl.cs
+++ b/UoFiddler.Controls/UserControls/FontsControl.cs
@@ -31,6 +31,8 @@ namespace UoFiddler.Controls.UserControls
 
             _refMarker = this;
             setOffsetsToolStripMenuItem.Visible = false;
+
+            splitContainer2.SplitterDistance = splitContainer2.Height - 40;
         }
 
         private bool _loaded;
@@ -104,24 +106,27 @@ namespace UoFiddler.Controls.UserControls
                     treeView.Nodes[0].Nodes.Add(node);
                 }
 
-                node = new TreeNode("Unicode")
+                if (LoadUnicodeFontsCheckBox.Checked)
                 {
-                    Tag = 1
-                };
-                treeView.Nodes.Add(node);
-
-                for (int i = 0; i < UnicodeFonts.Fonts.Length; ++i)
-                {
-                    if (UnicodeFonts.Fonts[i] == null)
+                    node = new TreeNode("Unicode")
                     {
-                        continue;
-                    }
-
-                    node = new TreeNode(i.ToString())
-                    {
-                        Tag = i
+                        Tag = 1
                     };
-                    treeView.Nodes[1].Nodes.Add(node);
+                    treeView.Nodes.Add(node);
+
+                    for (int i = 0; i < UnicodeFonts.Fonts.Length; ++i)
+                    {
+                        if (UnicodeFonts.Fonts[i] == null)
+                        {
+                            continue;
+                        }
+
+                        node = new TreeNode(i.ToString())
+                        {
+                            Tag = i
+                        };
+                        treeView.Nodes[1].Nodes.Add(node);
+                    }
                 }
 
                 treeView.ExpandAll();
@@ -185,6 +190,7 @@ namespace UoFiddler.Controls.UserControls
             }
             finally
             {
+                UpdateStatusStrip();
                 FontsTileView.Invalidate();
             }
         }
@@ -397,18 +403,46 @@ namespace UoFiddler.Controls.UserControls
                 return;
             }
 
+            UpdateStatusStrip();
+        }
+
+        private void UpdateStatusStrip()
+        {
             if (FontsTileView.SelectedIndices.Count == 0)
             {
-                toolStripStatusLabel1.Text = "<no selection>";
+                toolStripStatusLabel1.Text = string.Empty;
+                return;
             }
-            else
-            {
-                int i = FontsTileView.SelectedIndices[0];
 
-                toolStripStatusLabel1.Text = (int)treeView.SelectedNode.Parent.Tag == 1
-                    ? string.Format("'{0}' : {1} (0x{1:X}) XOffset: {2} YOffset: {3}", (char)i, i, UnicodeFonts.Fonts[(int)treeView.SelectedNode.Tag].Chars[i].XOffset, UnicodeFonts.Fonts[(int)treeView.SelectedNode.Tag].Chars[i].YOffset)
-                    : string.Format("'{0}' : {1} (0x{1:X})", (char)(_fonts[i] + AsciiFontOffset), _fonts[i] + AsciiFontOffset);
+            int i = FontsTileView.SelectedIndices[0];
+
+            toolStripStatusLabel1.Text = (int)treeView.SelectedNode.Parent.Tag == 1
+                ? string.Format("'{0}' : {1} (0x{1:X}) XOffset: {2} YOffset: {3}", (char)i, i,
+                    UnicodeFonts.Fonts[(int)treeView.SelectedNode.Tag].Chars[i].XOffset,
+                    UnicodeFonts.Fonts[(int)treeView.SelectedNode.Tag].Chars[i].YOffset)
+                : string.Format("'{0}' : {1} (0x{1:X})", (char)(_fonts[i] + AsciiFontOffset), _fonts[i] + AsciiFontOffset);
+        }
+
+        private void LoadUnicodeFontsCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            string message = LoadUnicodeFontsCheckBox.Checked
+                ? "Would you like to load all fonts including Unicode?"
+                : "Load only ASCII fonts?";
+
+            DialogResult result =
+                MessageBox.Show(message, "Fonts reload",
+                    MessageBoxButtons.YesNo, MessageBoxIcon.Question, MessageBoxDefaultButton.Button2);
+            if (result != DialogResult.Yes)
+            {
+                return;
             }
+
+            Reload();
+        }
+
+        private void FontsControl_Resize(object sender, EventArgs e)
+        {
+            splitContainer2.SplitterDistance = splitContainer2.Height - 40;
         }
     }
 }

--- a/UoFiddler.Controls/UserControls/FontsControl.resx
+++ b/UoFiddler.Controls/UserControls/FontsControl.resx
@@ -121,6 +121,6 @@
     <value>127, 17</value>
   </metadata>
   <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+    <value>282, 17</value>
   </metadata>
 </root>

--- a/UoFiddler.Controls/UserControls/ItemShowAlternativeControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/ItemShowAlternativeControl.Designer.cs
@@ -9,6 +9,8 @@
  *
  ***************************************************************************/
 
+using System.Windows.Forms;
+
 namespace UoFiddler.Controls.UserControls
 {
     partial class ItemShowAlternativeControl
@@ -42,13 +44,12 @@ namespace UoFiddler.Controls.UserControls
             this.components = new System.ComponentModel.Container();
             this.splitContainer2 = new System.Windows.Forms.SplitContainer();
             this.DetailPictureBox = new System.Windows.Forms.PictureBox();
-            this.contextMenuStrip2 = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.DetailPictureBoxContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.changeBackgroundColorToolStripMenuItemDetail = new System.Windows.Forms.ToolStripMenuItem();
             this.DetailTextBox = new System.Windows.Forms.RichTextBox();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
-            this.vScrollBar = new System.Windows.Forms.VScrollBar();
-            this.pictureBox = new System.Windows.Forms.PictureBox();
-            this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.ItemsTileView = new UoFiddler.Controls.UserControls.TileView.TileViewControl();
+            this.TileViewContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.showFreeSlotsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.findNextFreeSlotToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ChangeBackgroundColorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -67,36 +68,35 @@ namespace UoFiddler.Controls.UserControls
             this.InsertText = new System.Windows.Forms.ToolStripTextBox();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.statusStrip1 = new System.Windows.Forms.StatusStrip();
-            this.namelabel = new System.Windows.Forms.ToolStripStatusLabel();
-            this.graphiclabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.StatusStrip = new System.Windows.Forms.StatusStrip();
+            this.NameLabel = new System.Windows.Forms.ToolStripStatusLabel();
+            this.GraphicLabel = new System.Windows.Forms.ToolStripStatusLabel();
             this.PreLoader = new System.ComponentModel.BackgroundWorker();
-            this.collapsibleSplitter1 = new UoFiddler.Controls.UserControls.CollapsibleSplitter();
-            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
-            this.toolStripButton1 = new System.Windows.Forms.ToolStripButton();
+            this.ToolStrip = new System.Windows.Forms.ToolStrip();
+            this.SearchToolStripButton = new System.Windows.Forms.ToolStripButton();
             this.ProgressBar = new System.Windows.Forms.ToolStripProgressBar();
-            this.toolStripButton2 = new System.Windows.Forms.ToolStripButton();
-            this.toolStripDropDownButton1 = new System.Windows.Forms.ToolStripDropDownButton();
-            this.exportAllAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.PreloadItemsToolStripButton = new System.Windows.Forms.ToolStripButton();
+            this.MiscToolStripDropDownButton = new System.Windows.Forms.ToolStripDropDownButton();
+            this.ExportAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.asBmpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.asTiffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.asJpgToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.asPngToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.colorDialog = new System.Windows.Forms.ColorDialog();
+            this.collapsibleSplitter1 = new UoFiddler.Controls.UserControls.CollapsibleSplitter();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).BeginInit();
             this.splitContainer2.Panel1.SuspendLayout();
             this.splitContainer2.Panel2.SuspendLayout();
             this.splitContainer2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.DetailPictureBox)).BeginInit();
-            this.contextMenuStrip2.SuspendLayout();
+            this.DetailPictureBoxContextMenuStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox)).BeginInit();
-            this.contextMenuStrip1.SuspendLayout();
-            this.statusStrip1.SuspendLayout();
-            this.toolStrip1.SuspendLayout();
+            this.TileViewContextMenuStrip.SuspendLayout();
+            this.StatusStrip.SuspendLayout();
+            this.ToolStrip.SuspendLayout();
             this.SuspendLayout();
             // 
             // splitContainer2
@@ -113,26 +113,26 @@ namespace UoFiddler.Controls.UserControls
             // splitContainer2.Panel2
             // 
             this.splitContainer2.Panel2.Controls.Add(this.DetailTextBox);
-            this.splitContainer2.Size = new System.Drawing.Size(157, 270);
-            this.splitContainer2.SplitterDistance = 156;
+            this.splitContainer2.Size = new System.Drawing.Size(161, 284);
+            this.splitContainer2.SplitterDistance = 163;
             this.splitContainer2.TabIndex = 0;
             // 
             // DetailPictureBox
             // 
-            this.DetailPictureBox.ContextMenuStrip = this.contextMenuStrip2;
+            this.DetailPictureBox.ContextMenuStrip = this.DetailPictureBoxContextMenuStrip;
             this.DetailPictureBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.DetailPictureBox.Location = new System.Drawing.Point(0, 0);
             this.DetailPictureBox.Name = "DetailPictureBox";
-            this.DetailPictureBox.Size = new System.Drawing.Size(157, 156);
+            this.DetailPictureBox.Size = new System.Drawing.Size(161, 163);
             this.DetailPictureBox.TabIndex = 0;
             this.DetailPictureBox.TabStop = false;
             // 
-            // contextMenuStrip2
+            // DetailPictureBoxContextMenuStrip
             // 
-            this.contextMenuStrip2.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.DetailPictureBoxContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.changeBackgroundColorToolStripMenuItemDetail});
-            this.contextMenuStrip2.Name = "contextMenuStrip2";
-            this.contextMenuStrip2.Size = new System.Drawing.Size(213, 48);
+            this.DetailPictureBoxContextMenuStrip.Name = "contextMenuStrip2";
+            this.DetailPictureBoxContextMenuStrip.Size = new System.Drawing.Size(213, 26);
             // 
             // changeBackgroundColorToolStripMenuItemDetail
             // 
@@ -146,7 +146,7 @@ namespace UoFiddler.Controls.UserControls
             this.DetailTextBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.DetailTextBox.Location = new System.Drawing.Point(0, 0);
             this.DetailTextBox.Name = "DetailTextBox";
-            this.DetailTextBox.Size = new System.Drawing.Size(157, 110);
+            this.DetailTextBox.Size = new System.Drawing.Size(161, 117);
             this.DetailTextBox.TabIndex = 0;
             this.DetailTextBox.Text = "";
             // 
@@ -158,44 +158,46 @@ namespace UoFiddler.Controls.UserControls
             // 
             // splitContainer1.Panel1
             // 
-            this.splitContainer1.Panel1.Controls.Add(this.vScrollBar);
-            this.splitContainer1.Panel1.Controls.Add(this.pictureBox);
+            this.splitContainer1.Panel1.Controls.Add(this.ItemsTileView);
             // 
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.splitContainer2);
-            this.splitContainer1.Size = new System.Drawing.Size(623, 270);
-            this.splitContainer1.SplitterDistance = 462;
+            this.splitContainer1.Size = new System.Drawing.Size(636, 284);
+            this.splitContainer1.SplitterDistance = 471;
             this.splitContainer1.TabIndex = 6;
             // 
-            // vScrollBar
+            // ItemsTileView
             // 
-            this.vScrollBar.Dock = System.Windows.Forms.DockStyle.Right;
-            this.vScrollBar.Location = new System.Drawing.Point(445, 0);
-            this.vScrollBar.Margin = new System.Windows.Forms.Padding(3, 0, 0, 0);
-            this.vScrollBar.Name = "vScrollBar";
-            this.vScrollBar.Size = new System.Drawing.Size(17, 270);
-            this.vScrollBar.TabIndex = 0;
-            this.vScrollBar.Scroll += new System.Windows.Forms.ScrollEventHandler(this.OnScroll);
+            this.ItemsTileView.AutoScroll = true;
+            this.ItemsTileView.AutoScrollMinSize = new System.Drawing.Size(0, 102);
+            this.ItemsTileView.BackColor = System.Drawing.SystemColors.Window;
+            this.ItemsTileView.ContextMenuStrip = this.TileViewContextMenuStrip;
+            this.ItemsTileView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.ItemsTileView.FocusIndex = -1;
+            this.ItemsTileView.Location = new System.Drawing.Point(0, 0);
+            this.ItemsTileView.MultiSelect = true;
+            this.ItemsTileView.Name = "ItemsTileView";
+            this.ItemsTileView.Size = new System.Drawing.Size(471, 284);
+            this.ItemsTileView.TabIndex = 0;
+            this.ItemsTileView.TileBackgroundColor = System.Drawing.SystemColors.Window;
+            this.ItemsTileView.TileBorderColor = System.Drawing.Color.Gray;
+            this.ItemsTileView.TileBorderWidth = 1F;
+            this.ItemsTileView.TileHighlightColor = System.Drawing.SystemColors.Highlight;
+            this.ItemsTileView.TileMargin = new System.Windows.Forms.Padding(2, 2, 0, 0);
+            this.ItemsTileView.TilePadding = new System.Windows.Forms.Padding(1);
+            this.ItemsTileView.TileSize = new System.Drawing.Size(96, 96);
+            this.ItemsTileView.VirtualListSize = 1;
+            this.ItemsTileView.ItemSelectionChanged += new System.EventHandler<System.Windows.Forms.ListViewItemSelectionChangedEventArgs>(this.ItemsTileView_ItemSelectionChanged);
+            this.ItemsTileView.FocusSelectionChanged += new System.EventHandler<UoFiddler.Controls.UserControls.TileView.TileViewControl.ListViewFocusedItemSelectionChangedEventArgs>(this.ItemsTileView_FocusSelectionChanged);
+            this.ItemsTileView.DrawItem += new System.EventHandler<UoFiddler.Controls.UserControls.TileView.TileViewControl.DrawTileListItemEventArgs>(this.ItemsTileView_DrawItem);
+            this.ItemsTileView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.ItemsTileView_KeyDown);
+            this.ItemsTileView.KeyUp += new System.Windows.Forms.KeyEventHandler(this.ItemsTileView_KeyUp);
+            this.ItemsTileView.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.ItemsTileView_MouseDoubleClick);
             // 
-            // pictureBox
+            // TileViewContextMenuStrip
             // 
-            this.pictureBox.ContextMenuStrip = this.contextMenuStrip1;
-            this.pictureBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pictureBox.Location = new System.Drawing.Point(0, 0);
-            this.pictureBox.Margin = new System.Windows.Forms.Padding(0);
-            this.pictureBox.Name = "pictureBox";
-            this.pictureBox.Size = new System.Drawing.Size(462, 270);
-            this.pictureBox.TabIndex = 1;
-            this.pictureBox.TabStop = false;
-            this.pictureBox.SizeChanged += new System.EventHandler(this.OnResize);
-            this.pictureBox.Paint += new System.Windows.Forms.PaintEventHandler(this.OnPaint);
-            this.pictureBox.MouseClick += new System.Windows.Forms.MouseEventHandler(this.OnMouseClick);
-            this.pictureBox.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.OnMouseDoubleClick);
-            // 
-            // contextMenuStrip1
-            // 
-            this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.TileViewContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.showFreeSlotsToolStripMenuItem,
             this.findNextFreeSlotToolStripMenuItem,
             this.ChangeBackgroundColorToolStripMenuItem,
@@ -209,8 +211,8 @@ namespace UoFiddler.Controls.UserControls
             this.insertAtToolStripMenuItem,
             this.toolStripSeparator1,
             this.saveToolStripMenuItem});
-            this.contextMenuStrip1.Name = "contextMenuStrip1";
-            this.contextMenuStrip1.Size = new System.Drawing.Size(213, 242);
+            this.TileViewContextMenuStrip.Name = "contextMenuStrip1";
+            this.TileViewContextMenuStrip.Size = new System.Drawing.Size(213, 242);
             // 
             // showFreeSlotsToolStripMenuItem
             // 
@@ -339,34 +341,34 @@ namespace UoFiddler.Controls.UserControls
             this.saveToolStripMenuItem.Text = "Save";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.OnClickSave);
             // 
-            // statusStrip1
+            // StatusStrip
             // 
-            this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.namelabel,
-            this.graphiclabel});
-            this.statusStrip1.Location = new System.Drawing.Point(0, 303);
-            this.statusStrip1.Name = "statusStrip1";
-            this.statusStrip1.Size = new System.Drawing.Size(623, 22);
-            this.statusStrip1.TabIndex = 5;
-            this.statusStrip1.Text = "statusStrip1";
+            this.StatusStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.NameLabel,
+            this.GraphicLabel});
+            this.StatusStrip.Location = new System.Drawing.Point(0, 317);
+            this.StatusStrip.Name = "StatusStrip";
+            this.StatusStrip.Size = new System.Drawing.Size(636, 22);
+            this.StatusStrip.TabIndex = 5;
+            this.StatusStrip.Text = "statusStrip1";
             // 
-            // namelabel
+            // NameLabel
             // 
-            this.namelabel.AutoSize = false;
-            this.namelabel.BorderStyle = System.Windows.Forms.Border3DStyle.SunkenInner;
-            this.namelabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.namelabel.Name = "namelabel";
-            this.namelabel.Size = new System.Drawing.Size(200, 17);
-            this.namelabel.Text = "Name:";
-            this.namelabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.NameLabel.AutoSize = false;
+            this.NameLabel.BorderStyle = System.Windows.Forms.Border3DStyle.SunkenInner;
+            this.NameLabel.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.NameLabel.Name = "NameLabel";
+            this.NameLabel.Size = new System.Drawing.Size(200, 17);
+            this.NameLabel.Text = "Name:";
+            this.NameLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
-            // graphiclabel
+            // GraphicLabel
             // 
-            this.graphiclabel.AutoSize = false;
-            this.graphiclabel.Name = "graphiclabel";
-            this.graphiclabel.Size = new System.Drawing.Size(150, 17);
-            this.graphiclabel.Text = "Graphic:";
-            this.graphiclabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.GraphicLabel.AutoSize = false;
+            this.GraphicLabel.Name = "GraphicLabel";
+            this.GraphicLabel.Size = new System.Drawing.Size(150, 17);
+            this.GraphicLabel.Text = "Graphic:";
+            this.GraphicLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // PreLoader
             // 
@@ -375,44 +377,28 @@ namespace UoFiddler.Controls.UserControls
             this.PreLoader.ProgressChanged += new System.ComponentModel.ProgressChangedEventHandler(this.PreLoaderProgressChanged);
             this.PreLoader.RunWorkerCompleted += new System.ComponentModel.RunWorkerCompletedEventHandler(this.PreLoaderCompleted);
             // 
-            // collapsibleSplitter1
+            // ToolStrip
             // 
-            this.collapsibleSplitter1.AnimationDelay = 20;
-            this.collapsibleSplitter1.AnimationStep = 20;
-            this.collapsibleSplitter1.BorderStyle3D = System.Windows.Forms.Border3DStyle.Flat;
-            this.collapsibleSplitter1.ControlToHide = this.toolStrip1;
-            this.collapsibleSplitter1.Dock = System.Windows.Forms.DockStyle.Top;
-            this.collapsibleSplitter1.ExpandParentForm = false;
-            this.collapsibleSplitter1.Location = new System.Drawing.Point(0, 25);
-            this.collapsibleSplitter1.Name = "collapsibleSplitter1";
-            this.collapsibleSplitter1.TabIndex = 8;
-            this.collapsibleSplitter1.TabStop = false;
-            this.collapsibleSplitter1.UseAnimations = false;
-            this.collapsibleSplitter1.VisualStyle = UoFiddler.Controls.UserControls.VisualStyles.DoubleDots;
-            // 
-            // toolStrip1
-            // 
-            this.toolStrip1.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
-            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripButton1,
+            this.ToolStrip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
+            this.ToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.SearchToolStripButton,
             this.ProgressBar,
-            this.toolStripButton2,
-            this.toolStripDropDownButton1});
-            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-            this.toolStrip1.Size = new System.Drawing.Size(623, 25);
-            this.toolStrip1.TabIndex = 7;
-            this.toolStrip1.Text = "toolStrip1";
+            this.PreloadItemsToolStripButton,
+            this.MiscToolStripDropDownButton});
+            this.ToolStrip.Location = new System.Drawing.Point(0, 0);
+            this.ToolStrip.Name = "ToolStrip";
+            this.ToolStrip.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
+            this.ToolStrip.Size = new System.Drawing.Size(636, 25);
+            this.ToolStrip.TabIndex = 7;
             // 
-            // toolStripButton1
+            // SearchToolStripButton
             // 
-            this.toolStripButton1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton1.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripButton1.Name = "toolStripButton1";
-            this.toolStripButton1.Size = new System.Drawing.Size(46, 22);
-            this.toolStripButton1.Text = "Search";
-            this.toolStripButton1.Click += new System.EventHandler(this.OnSearchClick);
+            this.SearchToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.SearchToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.SearchToolStripButton.Name = "SearchToolStripButton";
+            this.SearchToolStripButton.Size = new System.Drawing.Size(46, 22);
+            this.SearchToolStripButton.Text = "Search";
+            this.SearchToolStripButton.Click += new System.EventHandler(this.OnSearchClick);
             // 
             // ProgressBar
             // 
@@ -420,36 +406,36 @@ namespace UoFiddler.Controls.UserControls
             this.ProgressBar.Name = "ProgressBar";
             this.ProgressBar.Size = new System.Drawing.Size(100, 22);
             // 
-            // toolStripButton2
+            // PreloadItemsToolStripButton
             // 
-            this.toolStripButton2.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.toolStripButton2.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripButton2.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripButton2.Name = "toolStripButton2";
-            this.toolStripButton2.Size = new System.Drawing.Size(83, 22);
-            this.toolStripButton2.Text = "Preload Items";
-            this.toolStripButton2.Click += new System.EventHandler(this.OnClickPreLoad);
+            this.PreloadItemsToolStripButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.PreloadItemsToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.PreloadItemsToolStripButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.PreloadItemsToolStripButton.Name = "PreloadItemsToolStripButton";
+            this.PreloadItemsToolStripButton.Size = new System.Drawing.Size(83, 22);
+            this.PreloadItemsToolStripButton.Text = "Preload Items";
+            this.PreloadItemsToolStripButton.Click += new System.EventHandler(this.OnClickPreLoad);
             // 
-            // toolStripDropDownButton1
+            // MiscToolStripDropDownButton
             // 
-            this.toolStripDropDownButton1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripDropDownButton1.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.exportAllAsToolStripMenuItem});
-            this.toolStripDropDownButton1.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripDropDownButton1.Name = "toolStripDropDownButton1";
-            this.toolStripDropDownButton1.Size = new System.Drawing.Size(45, 22);
-            this.toolStripDropDownButton1.Text = "Misc";
+            this.MiscToolStripDropDownButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.MiscToolStripDropDownButton.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ExportAllToolStripMenuItem});
+            this.MiscToolStripDropDownButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.MiscToolStripDropDownButton.Name = "MiscToolStripDropDownButton";
+            this.MiscToolStripDropDownButton.Size = new System.Drawing.Size(45, 22);
+            this.MiscToolStripDropDownButton.Text = "Misc";
             // 
-            // exportAllAsToolStripMenuItem
+            // ExportAllToolStripMenuItem
             // 
-            this.exportAllAsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ExportAllToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.asBmpToolStripMenuItem,
             this.asTiffToolStripMenuItem,
             this.asJpgToolStripMenuItem,
             this.asPngToolStripMenuItem});
-            this.exportAllAsToolStripMenuItem.Name = "exportAllAsToolStripMenuItem";
-            this.exportAllAsToolStripMenuItem.Size = new System.Drawing.Size(129, 22);
-            this.exportAllAsToolStripMenuItem.Text = "Export all..";
+            this.ExportAllToolStripMenuItem.Name = "ExportAllToolStripMenuItem";
+            this.ExportAllToolStripMenuItem.Size = new System.Drawing.Size(129, 22);
+            this.ExportAllToolStripMenuItem.Text = "Export all..";
             // 
             // asBmpToolStripMenuItem
             // 
@@ -479,34 +465,48 @@ namespace UoFiddler.Controls.UserControls
             this.asPngToolStripMenuItem.Text = "As Png";
             this.asPngToolStripMenuItem.Click += new System.EventHandler(this.OnClick_SaveAllPng);
             // 
+            // collapsibleSplitter1
+            // 
+            this.collapsibleSplitter1.AnimationDelay = 20;
+            this.collapsibleSplitter1.AnimationStep = 20;
+            this.collapsibleSplitter1.BorderStyle3D = System.Windows.Forms.Border3DStyle.Flat;
+            this.collapsibleSplitter1.ControlToHide = this.ToolStrip;
+            this.collapsibleSplitter1.Dock = System.Windows.Forms.DockStyle.Top;
+            this.collapsibleSplitter1.ExpandParentForm = false;
+            this.collapsibleSplitter1.Location = new System.Drawing.Point(0, 25);
+            this.collapsibleSplitter1.Name = "collapsibleSplitter1";
+            this.collapsibleSplitter1.TabIndex = 8;
+            this.collapsibleSplitter1.TabStop = false;
+            this.collapsibleSplitter1.UseAnimations = false;
+            this.collapsibleSplitter1.VisualStyle = UoFiddler.Controls.UserControls.VisualStyles.DoubleDots;
+            // 
             // ItemShowAlternativeControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.splitContainer1);
-            this.Controls.Add(this.statusStrip1);
+            this.Controls.Add(this.StatusStrip);
             this.Controls.Add(this.collapsibleSplitter1);
-            this.Controls.Add(this.toolStrip1);
+            this.Controls.Add(this.ToolStrip);
             this.DoubleBuffered = true;
             this.Name = "ItemShowAlternativeControl";
-            this.Size = new System.Drawing.Size(623, 325);
+            this.Size = new System.Drawing.Size(636, 339);
             this.Load += new System.EventHandler(this.OnLoad);
             this.splitContainer2.Panel1.ResumeLayout(false);
             this.splitContainer2.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer2)).EndInit();
             this.splitContainer2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.DetailPictureBox)).EndInit();
-            this.contextMenuStrip2.ResumeLayout(false);
+            this.DetailPictureBoxContextMenuStrip.ResumeLayout(false);
             this.splitContainer1.Panel1.ResumeLayout(false);
             this.splitContainer1.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
             this.splitContainer1.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox)).EndInit();
-            this.contextMenuStrip1.ResumeLayout(false);
-            this.statusStrip1.ResumeLayout(false);
-            this.statusStrip1.PerformLayout();
-            this.toolStrip1.ResumeLayout(false);
-            this.toolStrip1.PerformLayout();
+            this.TileViewContextMenuStrip.ResumeLayout(false);
+            this.StatusStrip.ResumeLayout(false);
+            this.StatusStrip.PerformLayout();
+            this.ToolStrip.ResumeLayout(false);
+            this.ToolStrip.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -520,17 +520,15 @@ namespace UoFiddler.Controls.UserControls
         private System.Windows.Forms.ToolStripMenuItem asTiffToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem bmpToolStripMenuItem;
         private UoFiddler.Controls.UserControls.CollapsibleSplitter collapsibleSplitter1;
-        private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
+        private System.Windows.Forms.ContextMenuStrip TileViewContextMenuStrip;
         private System.Windows.Forms.PictureBox DetailPictureBox;
-        private System.Windows.Forms.RichTextBox DetailTextBox;
-        private System.Windows.Forms.ToolStripMenuItem exportAllAsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem ExportAllToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem extractToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem findNextFreeSlotToolStripMenuItem;
-        private System.Windows.Forms.ToolStripStatusLabel graphiclabel;
+        private System.Windows.Forms.ToolStripStatusLabel GraphicLabel;
         private System.Windows.Forms.ToolStripMenuItem insertAtToolStripMenuItem;
         private System.Windows.Forms.ToolStripTextBox InsertText;
-        private System.Windows.Forms.ToolStripStatusLabel namelabel;
-        private System.Windows.Forms.PictureBox pictureBox;
+        private System.Windows.Forms.ToolStripStatusLabel NameLabel;
         private System.ComponentModel.BackgroundWorker PreLoader;
         private System.Windows.Forms.ToolStripProgressBar ProgressBar;
         private System.Windows.Forms.ToolStripMenuItem removeToolStripMenuItem;
@@ -541,22 +539,23 @@ namespace UoFiddler.Controls.UserControls
         private System.Windows.Forms.ToolStripMenuItem showFreeSlotsToolStripMenuItem;
         private System.Windows.Forms.SplitContainer splitContainer1;
         private System.Windows.Forms.SplitContainer splitContainer2;
-        private System.Windows.Forms.StatusStrip statusStrip1;
+        private System.Windows.Forms.StatusStrip StatusStrip;
         private System.Windows.Forms.ToolStripMenuItem tiffToolStripMenuItem;
-        private System.Windows.Forms.ToolStrip toolStrip1;
-        private System.Windows.Forms.ToolStripButton toolStripButton1;
-        private System.Windows.Forms.ToolStripButton toolStripButton2;
-        private System.Windows.Forms.ToolStripDropDownButton toolStripDropDownButton1;
+        private System.Windows.Forms.ToolStrip ToolStrip;
+        private System.Windows.Forms.ToolStripButton SearchToolStripButton;
+        private System.Windows.Forms.ToolStripButton PreloadItemsToolStripButton;
+        private System.Windows.Forms.ToolStripDropDownButton MiscToolStripDropDownButton;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
-        private System.Windows.Forms.VScrollBar vScrollBar;
 
         #endregion
 
-        private System.Windows.Forms.ContextMenuStrip contextMenuStrip2;
+        private System.Windows.Forms.ContextMenuStrip DetailPictureBoxContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem changeBackgroundColorToolStripMenuItemDetail;
         private System.Windows.Forms.ColorDialog colorDialog;
         private System.Windows.Forms.ToolStripMenuItem ChangeBackgroundColorToolStripMenuItem;
+        private TileView.TileViewControl ItemsTileView;
+        private RichTextBox DetailTextBox;
     }
 }

--- a/UoFiddler.Controls/UserControls/ItemShowAlternativeControl.resx
+++ b/UoFiddler.Controls/UserControls/ItemShowAlternativeControl.resx
@@ -117,22 +117,22 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="contextMenuStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>478, 18</value>
+  <metadata name="DetailPictureBoxContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>563, 15</value>
   </metadata>
-  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="TileViewContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>229, 18</value>
   </metadata>
-  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="StatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
   <metadata name="PreLoader.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>127, 17</value>
   </metadata>
-  <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>373, 18</value>
+  <metadata name="ToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>440, 15</value>
   </metadata>
   <metadata name="colorDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>633, 18</value>
+    <value>804, 18</value>
   </metadata>
 </root>

--- a/UoFiddler.Controls/UserControls/LandTilesAlternativeControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/LandTilesAlternativeControl.Designer.cs
@@ -73,6 +73,7 @@ namespace UoFiddler.Controls.UserControls
             this.SaveButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this.LandTilesTileView = new UoFiddler.Controls.UserControls.TileView.TileViewControl();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.LandTilesContextMenuStrip.SuspendLayout();
             this.LandTilesToolStrip.SuspendLayout();
             this.SuspendLayout();
@@ -186,6 +187,7 @@ namespace UoFiddler.Controls.UserControls
             // 
             // InsertText
             // 
+            this.InsertText.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.InsertText.Name = "InsertText";
             this.InsertText.Size = new System.Drawing.Size(100, 23);
             this.InsertText.KeyDown += new System.Windows.Forms.KeyEventHandler(this.OnKeyDownInsert);
@@ -199,8 +201,9 @@ namespace UoFiddler.Controls.UserControls
             this.GraphicLabel,
             this.FlagsLabel,
             this.MiscToolStripDropDownButton,
-            this.SearchButton,
             this.toolStripSeparator5,
+            this.SearchButton,
+            this.toolStripSeparator1,
             this.SaveButton,
             this.toolStripSeparator4});
             this.LandTilesToolStrip.Location = new System.Drawing.Point(0, 0);
@@ -252,7 +255,7 @@ namespace UoFiddler.Controls.UserControls
             this.asJpgToolStripMenuItem,
             this.asPngToolStripMenuItem1});
             this.exportAllToolStripMenuItem.Name = "exportAllToolStripMenuItem";
-            this.exportAllToolStripMenuItem.Size = new System.Drawing.Size(131, 22);
+            this.exportAllToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.exportAllToolStripMenuItem.Text = "Export All..";
             // 
             // ExportAllAsBmp
@@ -339,6 +342,12 @@ namespace UoFiddler.Controls.UserControls
             this.LandTilesTileView.ItemSelectionChanged += new System.EventHandler<System.Windows.Forms.ListViewItemSelectionChangedEventArgs>(this.LandTilesTileView_ItemSelectionChanged);
             this.LandTilesTileView.DrawItem += new System.EventHandler<UoFiddler.Controls.UserControls.TileView.TileViewControl.DrawTileListItemEventArgs>(this.LandTilesTileView_DrawItem);
             // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
+            // 
             // LandTilesAlternativeControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -390,5 +399,6 @@ namespace UoFiddler.Controls.UserControls
         #endregion
 
         private TileView.TileViewControl LandTilesTileView;
+        private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
     }
 }

--- a/UoFiddler.Controls/UserControls/LandTilesAlternativeControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/LandTilesAlternativeControl.Designer.cs
@@ -9,6 +9,9 @@
  *
  ***************************************************************************/
 
+using System;
+using UoFiddler.Controls.UserControls.TileView;
+
 namespace UoFiddler.Controls.UserControls
 {
     partial class LandTilesAlternativeControl
@@ -40,9 +43,7 @@ namespace UoFiddler.Controls.UserControls
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            this.vScrollBar = new System.Windows.Forms.VScrollBar();
-            this.pictureBox = new System.Windows.Forms.PictureBox();
-            this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
+            this.LandTilesContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.exportImageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.asBmpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.asTiffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -57,11 +58,11 @@ namespace UoFiddler.Controls.UserControls
             this.replaceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.insertAtToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.InsertText = new System.Windows.Forms.ToolStripTextBox();
-            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
-            this.namelabel = new System.Windows.Forms.ToolStripLabel();
-            this.graphiclabel = new System.Windows.Forms.ToolStripLabel();
+            this.LandTilesToolStrip = new System.Windows.Forms.ToolStrip();
+            this.NameLabel = new System.Windows.Forms.ToolStripLabel();
+            this.GraphicLabel = new System.Windows.Forms.ToolStripLabel();
             this.FlagsLabel = new System.Windows.Forms.ToolStripLabel();
-            this.toolStripDropDownButton1 = new System.Windows.Forms.ToolStripDropDownButton();
+            this.MiscToolStripDropDownButton = new System.Windows.Forms.ToolStripDropDownButton();
             this.exportAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.ExportAllAsBmp = new System.Windows.Forms.ToolStripMenuItem();
             this.ExportAllAsTiff = new System.Windows.Forms.ToolStripMenuItem();
@@ -71,38 +72,14 @@ namespace UoFiddler.Controls.UserControls
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
             this.SaveButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox)).BeginInit();
-            this.contextMenuStrip1.SuspendLayout();
-            this.toolStrip1.SuspendLayout();
+            this.LandTilesTileView = new UoFiddler.Controls.UserControls.TileView.TileViewControl();
+            this.LandTilesContextMenuStrip.SuspendLayout();
+            this.LandTilesToolStrip.SuspendLayout();
             this.SuspendLayout();
             // 
-            // vScrollBar
+            // LandTilesContextMenuStrip
             // 
-            this.vScrollBar.Dock = System.Windows.Forms.DockStyle.Right;
-            this.vScrollBar.Location = new System.Drawing.Point(602, 25);
-            this.vScrollBar.Name = "vScrollBar";
-            this.vScrollBar.Size = new System.Drawing.Size(17, 300);
-            this.vScrollBar.TabIndex = 7;
-            this.vScrollBar.Scroll += new System.Windows.Forms.ScrollEventHandler(this.OnScroll);
-            // 
-            // pictureBox
-            // 
-            this.pictureBox.ContextMenuStrip = this.contextMenuStrip1;
-            this.pictureBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pictureBox.Location = new System.Drawing.Point(0, 25);
-            this.pictureBox.Margin = new System.Windows.Forms.Padding(0, 0, 10, 0);
-            this.pictureBox.Name = "pictureBox";
-            this.pictureBox.Padding = new System.Windows.Forms.Padding(0, 0, 10, 0);
-            this.pictureBox.Size = new System.Drawing.Size(602, 300);
-            this.pictureBox.TabIndex = 3;
-            this.pictureBox.TabStop = false;
-            this.pictureBox.SizeChanged += new System.EventHandler(this.OnResize);
-            this.pictureBox.Paint += new System.Windows.Forms.PaintEventHandler(this.OnPaint);
-            this.pictureBox.MouseClick += new System.Windows.Forms.MouseEventHandler(this.OnMouseClick);
-            // 
-            // contextMenuStrip1
-            // 
-            this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.LandTilesContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.exportImageToolStripMenuItem,
             this.toolStripSeparator3,
             this.selectInTileDataTabToolStripMenuItem,
@@ -112,8 +89,8 @@ namespace UoFiddler.Controls.UserControls
             this.removeToolStripMenuItem,
             this.replaceToolStripMenuItem,
             this.insertAtToolStripMenuItem});
-            this.contextMenuStrip1.Name = "contextMenuStrip1";
-            this.contextMenuStrip1.Size = new System.Drawing.Size(201, 170);
+            this.LandTilesContextMenuStrip.Name = "contextMenuStrip1";
+            this.LandTilesContextMenuStrip.Size = new System.Drawing.Size(201, 170);
             // 
             // exportImageToolStripMenuItem
             // 
@@ -209,46 +186,44 @@ namespace UoFiddler.Controls.UserControls
             // 
             // InsertText
             // 
-            this.InsertText.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.InsertText.Name = "InsertText";
             this.InsertText.Size = new System.Drawing.Size(100, 23);
             this.InsertText.KeyDown += new System.Windows.Forms.KeyEventHandler(this.OnKeyDownInsert);
             this.InsertText.TextChanged += new System.EventHandler(this.OnTextChangedInsert);
             // 
-            // toolStrip1
+            // LandTilesToolStrip
             // 
-            this.toolStrip1.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
-            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.namelabel,
-            this.graphiclabel,
+            this.LandTilesToolStrip.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
+            this.LandTilesToolStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.NameLabel,
+            this.GraphicLabel,
             this.FlagsLabel,
-            this.toolStripDropDownButton1,
+            this.MiscToolStripDropDownButton,
             this.SearchButton,
             this.toolStripSeparator5,
             this.SaveButton,
             this.toolStripSeparator4});
-            this.toolStrip1.Location = new System.Drawing.Point(0, 0);
-            this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-            this.toolStrip1.Size = new System.Drawing.Size(619, 25);
-            this.toolStrip1.TabIndex = 5;
-            this.toolStrip1.Text = "toolStrip1";
+            this.LandTilesToolStrip.Location = new System.Drawing.Point(0, 0);
+            this.LandTilesToolStrip.Name = "LandTilesToolStrip";
+            this.LandTilesToolStrip.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
+            this.LandTilesToolStrip.Size = new System.Drawing.Size(610, 25);
+            this.LandTilesToolStrip.TabIndex = 5;
             // 
-            // namelabel
+            // NameLabel
             // 
-            this.namelabel.AutoSize = false;
-            this.namelabel.Name = "namelabel";
-            this.namelabel.Size = new System.Drawing.Size(140, 22);
-            this.namelabel.Text = "Name:";
-            this.namelabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.NameLabel.AutoSize = false;
+            this.NameLabel.Name = "NameLabel";
+            this.NameLabel.Size = new System.Drawing.Size(140, 22);
+            this.NameLabel.Text = "Name:";
+            this.NameLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
-            // graphiclabel
+            // GraphicLabel
             // 
-            this.graphiclabel.AutoSize = false;
-            this.graphiclabel.Name = "graphiclabel";
-            this.graphiclabel.Size = new System.Drawing.Size(120, 22);
-            this.graphiclabel.Text = "Graphic:";
-            this.graphiclabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            this.GraphicLabel.AutoSize = false;
+            this.GraphicLabel.Name = "GraphicLabel";
+            this.GraphicLabel.Size = new System.Drawing.Size(120, 22);
+            this.GraphicLabel.Text = "Graphic:";
+            this.GraphicLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // FlagsLabel
             // 
@@ -257,17 +232,17 @@ namespace UoFiddler.Controls.UserControls
             this.FlagsLabel.Text = "Flags:";
             this.FlagsLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
-            // toolStripDropDownButton1
+            // MiscToolStripDropDownButton
             // 
-            this.toolStripDropDownButton1.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.toolStripDropDownButton1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolStripDropDownButton1.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.MiscToolStripDropDownButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.MiscToolStripDropDownButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.MiscToolStripDropDownButton.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.exportAllToolStripMenuItem});
-            this.toolStripDropDownButton1.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripDropDownButton1.Margin = new System.Windows.Forms.Padding(0, 1, 20, 2);
-            this.toolStripDropDownButton1.Name = "toolStripDropDownButton1";
-            this.toolStripDropDownButton1.Size = new System.Drawing.Size(45, 22);
-            this.toolStripDropDownButton1.Text = "Misc";
+            this.MiscToolStripDropDownButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.MiscToolStripDropDownButton.Margin = new System.Windows.Forms.Padding(0, 1, 20, 2);
+            this.MiscToolStripDropDownButton.Name = "MiscToolStripDropDownButton";
+            this.MiscToolStripDropDownButton.Size = new System.Drawing.Size(45, 22);
+            this.MiscToolStripDropDownButton.Text = "Misc";
             // 
             // exportAllToolStripMenuItem
             // 
@@ -340,21 +315,43 @@ namespace UoFiddler.Controls.UserControls
             this.toolStripSeparator4.Name = "toolStripSeparator4";
             this.toolStripSeparator4.Size = new System.Drawing.Size(6, 25);
             // 
-            // LandTilesAlternative
+            // LandTilesTileView
+            // 
+            this.LandTilesTileView.AutoScroll = true;
+            this.LandTilesTileView.AutoScrollMinSize = new System.Drawing.Size(0, 50);
+            this.LandTilesTileView.BackColor = System.Drawing.SystemColors.Window;
+            this.LandTilesTileView.ContextMenuStrip = this.LandTilesContextMenuStrip;
+            this.LandTilesTileView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.LandTilesTileView.FocusIndex = -1;
+            this.LandTilesTileView.Location = new System.Drawing.Point(0, 25);
+            this.LandTilesTileView.MultiSelect = false;
+            this.LandTilesTileView.Name = "LandTilesTileView";
+            this.LandTilesTileView.Size = new System.Drawing.Size(610, 321);
+            this.LandTilesTileView.TabIndex = 8;
+            this.LandTilesTileView.TileBackgroundColor = System.Drawing.SystemColors.Window;
+            this.LandTilesTileView.TileBorderColor = System.Drawing.Color.Gray;
+            this.LandTilesTileView.TileBorderWidth = 1F;
+            this.LandTilesTileView.TileHighlightColor = System.Drawing.SystemColors.Highlight;
+            this.LandTilesTileView.TileMargin = new System.Windows.Forms.Padding(2, 2, 0, 0);
+            this.LandTilesTileView.TilePadding = new System.Windows.Forms.Padding(1);
+            this.LandTilesTileView.TileSize = new System.Drawing.Size(44, 44);
+            this.LandTilesTileView.VirtualListSize = 1;
+            this.LandTilesTileView.ItemSelectionChanged += new System.EventHandler<System.Windows.Forms.ListViewItemSelectionChangedEventArgs>(this.LandTilesTileView_ItemSelectionChanged);
+            this.LandTilesTileView.DrawItem += new System.EventHandler<UoFiddler.Controls.UserControls.TileView.TileViewControl.DrawTileListItemEventArgs>(this.LandTilesTileView_DrawItem);
+            // 
+            // LandTilesAlternativeControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.pictureBox);
-            this.Controls.Add(this.vScrollBar);
-            this.Controls.Add(this.toolStrip1);
+            this.Controls.Add(this.LandTilesTileView);
+            this.Controls.Add(this.LandTilesToolStrip);
             this.DoubleBuffered = true;
             this.Name = "LandTilesAlternativeControl";
-            this.Size = new System.Drawing.Size(619, 325);
+            this.Size = new System.Drawing.Size(610, 346);
             this.Load += new System.EventHandler(this.OnLoad);
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox)).EndInit();
-            this.contextMenuStrip1.ResumeLayout(false);
-            this.toolStrip1.ResumeLayout(false);
-            this.toolStrip1.PerformLayout();
+            this.LandTilesContextMenuStrip.ResumeLayout(false);
+            this.LandTilesToolStrip.ResumeLayout(false);
+            this.LandTilesToolStrip.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -366,32 +363,32 @@ namespace UoFiddler.Controls.UserControls
         private System.Windows.Forms.ToolStripMenuItem asPngToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem asPngToolStripMenuItem1;
         private System.Windows.Forms.ToolStripMenuItem asTiffToolStripMenuItem;
-        private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
+        private System.Windows.Forms.ContextMenuStrip LandTilesContextMenuStrip;
         private System.Windows.Forms.ToolStripMenuItem ExportAllAsBmp;
         private System.Windows.Forms.ToolStripMenuItem ExportAllAsTiff;
         private System.Windows.Forms.ToolStripMenuItem exportAllToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem exportImageToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem findNextFreeSlotToolStripMenuItem;
         private System.Windows.Forms.ToolStripLabel FlagsLabel;
-        private System.Windows.Forms.ToolStripLabel graphiclabel;
+        private System.Windows.Forms.ToolStripLabel GraphicLabel;
         private System.Windows.Forms.ToolStripMenuItem insertAtToolStripMenuItem;
         private System.Windows.Forms.ToolStripTextBox InsertText;
-        private System.Windows.Forms.ToolStripLabel namelabel;
-        private System.Windows.Forms.PictureBox pictureBox;
+        private System.Windows.Forms.ToolStripLabel NameLabel;
         private System.Windows.Forms.ToolStripMenuItem removeToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem replaceToolStripMenuItem;
         private System.Windows.Forms.ToolStripButton SaveButton;
         private System.Windows.Forms.ToolStripButton SearchButton;
         private System.Windows.Forms.ToolStripMenuItem selectInRadarColorTabToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem selectInTileDataTabToolStripMenuItem;
-        private System.Windows.Forms.ToolStrip toolStrip1;
-        private System.Windows.Forms.ToolStripDropDownButton toolStripDropDownButton1;
+        private System.Windows.Forms.ToolStrip LandTilesToolStrip;
+        private System.Windows.Forms.ToolStripDropDownButton MiscToolStripDropDownButton;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
-        private System.Windows.Forms.VScrollBar vScrollBar;
 
         #endregion
+
+        private TileView.TileViewControl LandTilesTileView;
     }
 }

--- a/UoFiddler.Controls/UserControls/LandTilesAlternativeControl.cs
+++ b/UoFiddler.Controls/UserControls/LandTilesAlternativeControl.cs
@@ -73,7 +73,6 @@ namespace UoFiddler.Controls.UserControls
             _refMarker.SelectedGraphicId = graphic;
 
             return true;
-
         }
 
         /// <summary>
@@ -546,6 +545,8 @@ namespace UoFiddler.Controls.UserControls
                     return;
                 }
 
+                Cursor.Current = Cursors.WaitCursor;
+
                 foreach (var index in _tileList)
                 {
                     if (!Art.IsValidLand(index))
@@ -560,7 +561,9 @@ namespace UoFiddler.Controls.UserControls
                     }
                 }
 
-                MessageBox.Show($"All LandTiles saved to {dialog.SelectedPath}", "Saved", MessageBoxButtons.OK,
+                Cursor.Current = Cursors.Default;
+
+                MessageBox.Show($"All land tiles saved to {dialog.SelectedPath}", "Saved", MessageBoxButtons.OK,
                     MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);
             }
         }

--- a/UoFiddler.Controls/UserControls/LandTilesAlternativeControl.resx
+++ b/UoFiddler.Controls/UserControls/LandTilesAlternativeControl.resx
@@ -117,10 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+  <metadata name="LandTilesContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>163, 18</value>
+  <metadata name="LandTilesToolStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>222, 21</value>
   </metadata>
 </root>

--- a/UoFiddler.Controls/UserControls/LandTilesControl.cs
+++ b/UoFiddler.Controls/UserControls/LandTilesControl.cs
@@ -768,14 +768,14 @@ namespace UoFiddler.Controls.UserControls
         private static void ExportLandTileImage(int index, ImageFormat imageFormat)
         {
             string fileExtension = Utils.GetFileExtensionFor(imageFormat);
-            string fileName = Path.Combine(Options.OutputPath, $"Landtile {index}.{fileExtension}");
+            string fileName = Path.Combine(Options.OutputPath, $"Landtile 0x{index:X4}.{fileExtension}");
 
             using (Bitmap bit = new Bitmap(Art.GetLand(index)))
             {
                 bit.Save(fileName, imageFormat);
             }
 
-            MessageBox.Show($"Landtile saved to {fileName}", "Saved", MessageBoxButtons.OK, MessageBoxIcon.Information,
+            MessageBox.Show($"Land tile saved to {fileName}", "Saved", MessageBoxButtons.OK, MessageBoxIcon.Information,
                 MessageBoxDefaultButton.Button1);
         }
 
@@ -834,6 +834,8 @@ namespace UoFiddler.Controls.UserControls
                     return;
                 }
 
+                Cursor.Current = Cursors.WaitCursor;
+
                 for (int i = 0; i < listView1.Items.Count; ++i)
                 {
                     int index = (int)listView1.Items[i].Tag;
@@ -842,14 +844,16 @@ namespace UoFiddler.Controls.UserControls
                         continue;
                     }
 
-                    string fileName = Path.Combine(dialog.SelectedPath, $"Landtile {index}.{fileExtension}");
+                    string fileName = Path.Combine(dialog.SelectedPath, $"Landtile 0x{index:X4}.{fileExtension}");
                     using (Bitmap bit = new Bitmap(Art.GetLand(index)))
                     {
                         bit.Save(fileName, imageFormat);
                     }
                 }
 
-                MessageBox.Show($"All LandTiles saved to {dialog.SelectedPath}", "Saved", MessageBoxButtons.OK,
+                Cursor.Current = Cursors.Default;
+
+                MessageBox.Show($"All land tiles saved to {dialog.SelectedPath}", "Saved", MessageBoxButtons.OK,
                     MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);
             }
         }

--- a/UoFiddler.Controls/UserControls/RadarColorControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/RadarColorControl.Designer.cs
@@ -95,7 +95,7 @@ namespace UoFiddler.Controls.UserControls
             this.treeViewItem.HideSelection = false;
             this.treeViewItem.Location = new System.Drawing.Point(3, 3);
             this.treeViewItem.Name = "treeViewItem";
-            this.treeViewItem.Size = new System.Drawing.Size(191, 162);
+            this.treeViewItem.Size = new System.Drawing.Size(193, 164);
             this.treeViewItem.TabIndex = 0;
             this.treeViewItem.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.AfterSelectTreeViewItem);
             // 
@@ -145,7 +145,7 @@ namespace UoFiddler.Controls.UserControls
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
             this.toolStripMenuItem1.Size = new System.Drawing.Size(188, 22);
             this.toolStripMenuItem1.Text = "Select in Landtiles tab";
-            this.toolStripMenuItem1.Click += new System.EventHandler(this.OnClickSelectLandtilesTab);
+            this.toolStripMenuItem1.Click += new System.EventHandler(this.OnClickSelectLandTilesTab);
             // 
             // toolStripMenuItem2
             // 
@@ -159,7 +159,7 @@ namespace UoFiddler.Controls.UserControls
             this.pictureBoxArt.Dock = System.Windows.Forms.DockStyle.Fill;
             this.pictureBoxArt.Location = new System.Drawing.Point(0, 0);
             this.pictureBoxArt.Name = "pictureBoxArt";
-            this.pictureBoxArt.Size = new System.Drawing.Size(205, 127);
+            this.pictureBoxArt.Size = new System.Drawing.Size(207, 130);
             this.pictureBoxArt.TabIndex = 0;
             this.pictureBoxArt.TabStop = false;
             // 
@@ -196,8 +196,8 @@ namespace UoFiddler.Controls.UserControls
             this.splitContainer5.Panel2.Controls.Add(this.button1);
             this.splitContainer5.Panel2.Controls.Add(this.buttonMean);
             this.splitContainer5.Panel2.Controls.Add(this.pictureBoxColor);
-            this.splitContainer5.Size = new System.Drawing.Size(620, 325);
-            this.splitContainer5.SplitterDistance = 205;
+            this.splitContainer5.Size = new System.Drawing.Size(628, 330);
+            this.splitContainer5.SplitterDistance = 207;
             this.splitContainer5.TabIndex = 1;
             // 
             // splitContainer6
@@ -214,8 +214,8 @@ namespace UoFiddler.Controls.UserControls
             // splitContainer6.Panel2
             // 
             this.splitContainer6.Panel2.Controls.Add(this.pictureBoxArt);
-            this.splitContainer6.Size = new System.Drawing.Size(205, 325);
-            this.splitContainer6.SplitterDistance = 194;
+            this.splitContainer6.Size = new System.Drawing.Size(207, 330);
+            this.splitContainer6.SplitterDistance = 196;
             this.splitContainer6.TabIndex = 0;
             // 
             // tabControl2
@@ -226,7 +226,7 @@ namespace UoFiddler.Controls.UserControls
             this.tabControl2.Location = new System.Drawing.Point(0, 0);
             this.tabControl2.Name = "tabControl2";
             this.tabControl2.SelectedIndex = 0;
-            this.tabControl2.Size = new System.Drawing.Size(205, 194);
+            this.tabControl2.Size = new System.Drawing.Size(207, 196);
             this.tabControl2.TabIndex = 0;
             // 
             // tabPage3
@@ -235,7 +235,7 @@ namespace UoFiddler.Controls.UserControls
             this.tabPage3.Location = new System.Drawing.Point(4, 22);
             this.tabPage3.Name = "tabPage3";
             this.tabPage3.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage3.Size = new System.Drawing.Size(197, 168);
+            this.tabPage3.Size = new System.Drawing.Size(199, 170);
             this.tabPage3.TabIndex = 0;
             this.tabPage3.Text = "Items";
             this.tabPage3.UseVisualStyleBackColor = true;
@@ -248,7 +248,7 @@ namespace UoFiddler.Controls.UserControls
             this.tabPage4.Padding = new System.Windows.Forms.Padding(3);
             this.tabPage4.Size = new System.Drawing.Size(197, 168);
             this.tabPage4.TabIndex = 1;
-            this.tabPage4.Text = "Landtiles";
+            this.tabPage4.Text = "Land Tiles";
             this.tabPage4.UseVisualStyleBackColor = true;
             // 
             // button5
@@ -307,7 +307,7 @@ namespace UoFiddler.Controls.UserControls
             this.button3.TabIndex = 11;
             this.button3.Text = "Average Color from-to";
             this.button3.UseVisualStyleBackColor = true;
-            this.button3.Click += new System.EventHandler(this.OnClickmeanColorFromTo);
+            this.button3.Click += new System.EventHandler(this.OnClickMeanColorFromTo);
             // 
             // numericUpDownB
             // 
@@ -378,14 +378,14 @@ namespace UoFiddler.Controls.UserControls
             this.buttonMean.UseVisualStyleBackColor = true;
             this.buttonMean.Click += new System.EventHandler(this.OnClickMeanColor);
             // 
-            // RadarColor
+            // RadarColorControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.splitContainer5);
             this.DoubleBuffered = true;
             this.Name = "RadarColorControl";
-            this.Size = new System.Drawing.Size(620, 325);
+            this.Size = new System.Drawing.Size(628, 330);
             this.Load += new System.EventHandler(this.OnLoad);
             this.contextMenuStrip1.ResumeLayout(false);
             this.contextMenuStrip2.ResumeLayout(false);

--- a/UoFiddler.Controls/UserControls/TextureAlternativeControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/TextureAlternativeControl.Designer.cs
@@ -40,7 +40,6 @@ namespace UoFiddler.Controls.UserControls
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            this.pictureBox = new System.Windows.Forms.PictureBox();
             this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.exportImageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.asBmpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -53,7 +52,6 @@ namespace UoFiddler.Controls.UserControls
             this.replaceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.insertAtToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.InsertText = new System.Windows.Forms.ToolStripTextBox();
-            this.vScrollBar = new System.Windows.Forms.VScrollBar();
             this.toolStrip1 = new System.Windows.Forms.ToolStrip();
             this.GraphicLabel = new System.Windows.Forms.ToolStripLabel();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
@@ -61,25 +59,10 @@ namespace UoFiddler.Controls.UserControls
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this.SaveButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox)).BeginInit();
+            this.TextureTileView = new UoFiddler.Controls.UserControls.TileView.TileViewControl();
             this.contextMenuStrip1.SuspendLayout();
             this.toolStrip1.SuspendLayout();
             this.SuspendLayout();
-            // 
-            // pictureBox
-            // 
-            this.pictureBox.ContextMenuStrip = this.contextMenuStrip1;
-            this.pictureBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pictureBox.Location = new System.Drawing.Point(0, 25);
-            this.pictureBox.Margin = new System.Windows.Forms.Padding(0, 0, 10, 0);
-            this.pictureBox.Name = "pictureBox";
-            this.pictureBox.Padding = new System.Windows.Forms.Padding(0, 0, 10, 0);
-            this.pictureBox.Size = new System.Drawing.Size(620, 300);
-            this.pictureBox.TabIndex = 3;
-            this.pictureBox.TabStop = false;
-            this.pictureBox.SizeChanged += new System.EventHandler(this.OnResize);
-            this.pictureBox.Paint += new System.Windows.Forms.PaintEventHandler(this.OnPaint);
-            this.pictureBox.MouseClick += new System.Windows.Forms.MouseEventHandler(this.OnMouseClick);
             // 
             // contextMenuStrip1
             // 
@@ -174,15 +157,6 @@ namespace UoFiddler.Controls.UserControls
             this.InsertText.KeyDown += new System.Windows.Forms.KeyEventHandler(this.OnKeyDownInsert);
             this.InsertText.TextChanged += new System.EventHandler(this.OnTextChangedInsert);
             // 
-            // vScrollBar
-            // 
-            this.vScrollBar.Dock = System.Windows.Forms.DockStyle.Right;
-            this.vScrollBar.Location = new System.Drawing.Point(603, 25);
-            this.vScrollBar.Name = "vScrollBar";
-            this.vScrollBar.Size = new System.Drawing.Size(17, 300);
-            this.vScrollBar.TabIndex = 4;
-            this.vScrollBar.Scroll += new System.Windows.Forms.ScrollEventHandler(this.OnScroll);
-            // 
             // toolStrip1
             // 
             this.toolStrip1.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
@@ -246,18 +220,39 @@ namespace UoFiddler.Controls.UserControls
             this.toolStripSeparator1.Name = "toolStripSeparator1";
             this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
             // 
-            // TextureAlternative
+            // TextureTileView
+            // 
+            this.TextureTileView.AutoScroll = true;
+            this.TextureTileView.AutoScrollMinSize = new System.Drawing.Size(0, 134);
+            this.TextureTileView.ContextMenuStrip = this.contextMenuStrip1;
+            this.TextureTileView.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.TextureTileView.FocusIndex = -1;
+            this.TextureTileView.Location = new System.Drawing.Point(0, 25);
+            this.TextureTileView.MultiSelect = false;
+            this.TextureTileView.Name = "TextureTileView";
+            this.TextureTileView.Size = new System.Drawing.Size(620, 300);
+            this.TextureTileView.TabIndex = 5;
+            this.TextureTileView.TileBackgroundColor = System.Drawing.SystemColors.Window;
+            this.TextureTileView.TileBorderColor = System.Drawing.Color.Gray;
+            this.TextureTileView.TileBorderWidth = 1F;
+            this.TextureTileView.TileHighlightColor = System.Drawing.SystemColors.Highlight;
+            this.TextureTileView.TileMargin = new System.Windows.Forms.Padding(2, 2, 0, 0);
+            this.TextureTileView.TilePadding = new System.Windows.Forms.Padding(1);
+            this.TextureTileView.TileSize = new System.Drawing.Size(128, 128);
+            this.TextureTileView.VirtualListSize = 1;
+            this.TextureTileView.ItemSelectionChanged += new System.EventHandler<System.Windows.Forms.ListViewItemSelectionChangedEventArgs>(this.TextureTileView_ItemSelectionChanged);
+            this.TextureTileView.DrawItem += new System.EventHandler<UoFiddler.Controls.UserControls.TileView.TileViewControl.DrawTileListItemEventArgs>(this.TextureTileView_DrawItem);
+            // 
+            // TextureAlternativeControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.vScrollBar);
-            this.Controls.Add(this.pictureBox);
+            this.Controls.Add(this.TextureTileView);
             this.Controls.Add(this.toolStrip1);
             this.DoubleBuffered = true;
             this.Name = "TextureAlternativeControl";
             this.Size = new System.Drawing.Size(620, 325);
             this.Load += new System.EventHandler(this.OnLoad);
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBox)).EndInit();
             this.contextMenuStrip1.ResumeLayout(false);
             this.toolStrip1.ResumeLayout(false);
             this.toolStrip1.PerformLayout();
@@ -276,7 +271,6 @@ namespace UoFiddler.Controls.UserControls
         private System.Windows.Forms.ToolStripLabel GraphicLabel;
         private System.Windows.Forms.ToolStripMenuItem insertAtToolStripMenuItem;
         private System.Windows.Forms.ToolStripTextBox InsertText;
-        private System.Windows.Forms.PictureBox pictureBox;
         private System.Windows.Forms.ToolStripMenuItem removeToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem replaceToolStripMenuItem;
         private System.Windows.Forms.ToolStripButton SaveButton;
@@ -286,8 +280,9 @@ namespace UoFiddler.Controls.UserControls
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator2;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
-        private System.Windows.Forms.VScrollBar vScrollBar;
 
         #endregion
+
+        private TileView.TileViewControl TextureTileView;
     }
 }

--- a/UoFiddler.Controls/UserControls/TextureAlternativeControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/TextureAlternativeControl.Designer.cs
@@ -54,6 +54,12 @@ namespace UoFiddler.Controls.UserControls
             this.InsertText = new System.Windows.Forms.ToolStripTextBox();
             this.toolStrip1 = new System.Windows.Forms.ToolStrip();
             this.GraphicLabel = new System.Windows.Forms.ToolStripLabel();
+            this.MiscToolStripDropDownButton = new System.Windows.Forms.ToolStripDropDownButton();
+            this.exportAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.ExportAllAsBmp = new System.Windows.Forms.ToolStripMenuItem();
+            this.ExportAllAsTiff = new System.Windows.Forms.ToolStripMenuItem();
+            this.ExportAllAsJpeg = new System.Windows.Forms.ToolStripMenuItem();
+            this.ExportAllAsPng = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.SearchButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
@@ -162,6 +168,7 @@ namespace UoFiddler.Controls.UserControls
             this.toolStrip1.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
             this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.GraphicLabel,
+            this.MiscToolStripDropDownButton,
             this.toolStripSeparator3,
             this.SearchButton,
             this.toolStripSeparator4,
@@ -180,6 +187,57 @@ namespace UoFiddler.Controls.UserControls
             this.GraphicLabel.Size = new System.Drawing.Size(51, 22);
             this.GraphicLabel.Text = "Graphic:";
             this.GraphicLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // MiscToolStripDropDownButton
+            // 
+            this.MiscToolStripDropDownButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.MiscToolStripDropDownButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.MiscToolStripDropDownButton.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.exportAllToolStripMenuItem});
+            this.MiscToolStripDropDownButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.MiscToolStripDropDownButton.Margin = new System.Windows.Forms.Padding(0, 1, 20, 2);
+            this.MiscToolStripDropDownButton.Name = "MiscToolStripDropDownButton";
+            this.MiscToolStripDropDownButton.Size = new System.Drawing.Size(45, 22);
+            this.MiscToolStripDropDownButton.Text = "Misc";
+            // 
+            // exportAllToolStripMenuItem
+            // 
+            this.exportAllToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ExportAllAsBmp,
+            this.ExportAllAsTiff,
+            this.ExportAllAsJpeg,
+            this.ExportAllAsPng});
+            this.exportAllToolStripMenuItem.Name = "exportAllToolStripMenuItem";
+            this.exportAllToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.exportAllToolStripMenuItem.Text = "Export All..";
+            // 
+            // ExportAllAsBmp
+            // 
+            this.ExportAllAsBmp.Name = "ExportAllAsBmp";
+            this.ExportAllAsBmp.Size = new System.Drawing.Size(180, 22);
+            this.ExportAllAsBmp.Text = "As Bmp";
+            this.ExportAllAsBmp.Click += new System.EventHandler(this.ExportAllAsBmp_Click);
+            // 
+            // ExportAllAsTiff
+            // 
+            this.ExportAllAsTiff.Name = "ExportAllAsTiff";
+            this.ExportAllAsTiff.Size = new System.Drawing.Size(180, 22);
+            this.ExportAllAsTiff.Text = "As Tiff";
+            this.ExportAllAsTiff.Click += new System.EventHandler(this.ExportAllAsTiff_Click);
+            // 
+            // ExportAllAsJpeg
+            // 
+            this.ExportAllAsJpeg.Name = "ExportAllAsJpeg";
+            this.ExportAllAsJpeg.Size = new System.Drawing.Size(180, 22);
+            this.ExportAllAsJpeg.Text = "As Jpg";
+            this.ExportAllAsJpeg.Click += new System.EventHandler(this.ExportAllAsJpeg_Click);
+            // 
+            // ExportAllAsPng
+            // 
+            this.ExportAllAsPng.Name = "ExportAllAsPng";
+            this.ExportAllAsPng.Size = new System.Drawing.Size(180, 22);
+            this.ExportAllAsPng.Text = "As Png";
+            this.ExportAllAsPng.Click += new System.EventHandler(this.ExportAllAsPng_Click);
             // 
             // toolStripSeparator3
             // 
@@ -284,5 +342,11 @@ namespace UoFiddler.Controls.UserControls
         #endregion
 
         private TileView.TileViewControl TextureTileView;
+        private System.Windows.Forms.ToolStripDropDownButton MiscToolStripDropDownButton;
+        private System.Windows.Forms.ToolStripMenuItem exportAllToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem ExportAllAsBmp;
+        private System.Windows.Forms.ToolStripMenuItem ExportAllAsTiff;
+        private System.Windows.Forms.ToolStripMenuItem ExportAllAsJpeg;
+        private System.Windows.Forms.ToolStripMenuItem ExportAllAsPng;
     }
 }

--- a/UoFiddler.Controls/UserControls/TextureAlternativeControl.cs
+++ b/UoFiddler.Controls/UserControls/TextureAlternativeControl.cs
@@ -481,6 +481,8 @@ namespace UoFiddler.Controls.UserControls
                     return;
                 }
 
+                Cursor.Current = Cursors.WaitCursor;
+
                 foreach (var index in _textureList)
                 {
                     if (!Textures.TestTexture(index))
@@ -494,6 +496,8 @@ namespace UoFiddler.Controls.UserControls
                         bit.Save(fileName, imageFormat);
                     }
                 }
+
+                Cursor.Current = Cursors.Default;
 
                 MessageBox.Show($"All textures saved to {dialog.SelectedPath}", "Saved", MessageBoxButtons.OK,
                     MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);

--- a/UoFiddler.Controls/UserControls/TextureAlternativeControl.cs
+++ b/UoFiddler.Controls/UserControls/TextureAlternativeControl.cs
@@ -447,5 +447,57 @@ namespace UoFiddler.Controls.UserControls
                 e.Graphics.DrawImage(bitmap, textureRectangle);
             }
         }
+
+        private void ExportAllAsBmp_Click(object sender, EventArgs e)
+        {
+            ExportAllTextures(ImageFormat.Bmp);
+        }
+
+        private void ExportAllAsTiff_Click(object sender, EventArgs e)
+        {
+            ExportAllTextures(ImageFormat.Tiff);
+        }
+
+        private void ExportAllAsJpeg_Click(object sender, EventArgs e)
+        {
+            ExportAllTextures(ImageFormat.Jpeg);
+        }
+
+        private void ExportAllAsPng_Click(object sender, EventArgs e)
+        {
+            ExportAllTextures(ImageFormat.Png);
+        }
+
+        private void ExportAllTextures(ImageFormat imageFormat)
+        {
+            string fileExtension = Utils.GetFileExtensionFor(imageFormat);
+
+            using (FolderBrowserDialog dialog = new FolderBrowserDialog())
+            {
+                dialog.Description = "Select directory";
+                dialog.ShowNewFolderButton = true;
+                if (dialog.ShowDialog() != DialogResult.OK)
+                {
+                    return;
+                }
+
+                foreach (var index in _textureList)
+                {
+                    if (!Textures.TestTexture(index))
+                    {
+                        continue;
+                    }
+
+                    string fileName = Path.Combine(dialog.SelectedPath, $"Texture 0x{index:X4}.{fileExtension}");
+                    using (Bitmap bit = new Bitmap(Textures.GetTexture(index)))
+                    {
+                        bit.Save(fileName, imageFormat);
+                    }
+                }
+
+                MessageBox.Show($"All textures saved to {dialog.SelectedPath}", "Saved", MessageBoxButtons.OK,
+                    MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);
+            }
+        }
     }
 }

--- a/UoFiddler.Controls/UserControls/TextureControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/TextureControl.Designer.cs
@@ -55,6 +55,12 @@ namespace UoFiddler.Controls.UserControls
             this.InsertText = new System.Windows.Forms.ToolStripTextBox();
             this.toolStrip1 = new System.Windows.Forms.ToolStrip();
             this.GraphicLabel = new System.Windows.Forms.ToolStripLabel();
+            this.MiscToolStripDropDownButton = new System.Windows.Forms.ToolStripDropDownButton();
+            this.exportAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.ExportAllAsBmp = new System.Windows.Forms.ToolStripMenuItem();
+            this.ExportAllAsTiff = new System.Windows.Forms.ToolStripMenuItem();
+            this.ExportAllAsJpeg = new System.Windows.Forms.ToolStripMenuItem();
+            this.ExportAllAsPng = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.SearchButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
@@ -182,6 +188,7 @@ namespace UoFiddler.Controls.UserControls
             this.toolStrip1.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
             this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.GraphicLabel,
+            this.MiscToolStripDropDownButton,
             this.toolStripSeparator1,
             this.SearchButton,
             this.toolStripSeparator4,
@@ -200,6 +207,57 @@ namespace UoFiddler.Controls.UserControls
             this.GraphicLabel.Size = new System.Drawing.Size(51, 22);
             this.GraphicLabel.Text = "Graphic:";
             this.GraphicLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // MiscToolStripDropDownButton
+            // 
+            this.MiscToolStripDropDownButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.MiscToolStripDropDownButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            this.MiscToolStripDropDownButton.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.exportAllToolStripMenuItem});
+            this.MiscToolStripDropDownButton.ImageTransparentColor = System.Drawing.Color.Magenta;
+            this.MiscToolStripDropDownButton.Margin = new System.Windows.Forms.Padding(0, 1, 20, 2);
+            this.MiscToolStripDropDownButton.Name = "MiscToolStripDropDownButton";
+            this.MiscToolStripDropDownButton.Size = new System.Drawing.Size(45, 22);
+            this.MiscToolStripDropDownButton.Text = "Misc";
+            // 
+            // exportAllToolStripMenuItem
+            // 
+            this.exportAllToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.ExportAllAsBmp,
+            this.ExportAllAsTiff,
+            this.ExportAllAsJpeg,
+            this.ExportAllAsPng});
+            this.exportAllToolStripMenuItem.Name = "exportAllToolStripMenuItem";
+            this.exportAllToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.exportAllToolStripMenuItem.Text = "Export All..";
+            // 
+            // ExportAllAsBmp
+            // 
+            this.ExportAllAsBmp.Name = "ExportAllAsBmp";
+            this.ExportAllAsBmp.Size = new System.Drawing.Size(180, 22);
+            this.ExportAllAsBmp.Text = "As Bmp";
+            this.ExportAllAsBmp.Click += new System.EventHandler(this.ExportAllAsBmp_Click);
+            // 
+            // ExportAllAsTiff
+            // 
+            this.ExportAllAsTiff.Name = "ExportAllAsTiff";
+            this.ExportAllAsTiff.Size = new System.Drawing.Size(180, 22);
+            this.ExportAllAsTiff.Text = "As Tiff";
+            this.ExportAllAsTiff.Click += new System.EventHandler(this.ExportAllAsTiff_Click);
+            // 
+            // ExportAllAsJpeg
+            // 
+            this.ExportAllAsJpeg.Name = "ExportAllAsJpeg";
+            this.ExportAllAsJpeg.Size = new System.Drawing.Size(180, 22);
+            this.ExportAllAsJpeg.Text = "As Jpg";
+            this.ExportAllAsJpeg.Click += new System.EventHandler(this.ExportAllAsJpeg_Click);
+            // 
+            // ExportAllAsPng
+            // 
+            this.ExportAllAsPng.Name = "ExportAllAsPng";
+            this.ExportAllAsPng.Size = new System.Drawing.Size(180, 22);
+            this.ExportAllAsPng.Text = "As Png";
+            this.ExportAllAsPng.Click += new System.EventHandler(this.ExportAllAsPng_Click);
             // 
             // toolStripSeparator1
             // 
@@ -239,7 +297,7 @@ namespace UoFiddler.Controls.UserControls
             this.toolStripSeparator3.Name = "toolStripSeparator3";
             this.toolStripSeparator3.Size = new System.Drawing.Size(6, 25);
             // 
-            // Texture
+            // TextureControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
@@ -280,5 +338,12 @@ namespace UoFiddler.Controls.UserControls
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator4;
 
         #endregion
+
+        private System.Windows.Forms.ToolStripDropDownButton MiscToolStripDropDownButton;
+        private System.Windows.Forms.ToolStripMenuItem exportAllToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem ExportAllAsBmp;
+        private System.Windows.Forms.ToolStripMenuItem ExportAllAsTiff;
+        private System.Windows.Forms.ToolStripMenuItem ExportAllAsJpeg;
+        private System.Windows.Forms.ToolStripMenuItem ExportAllAsPng;
     }
 }

--- a/UoFiddler.Controls/UserControls/TextureControl.cs
+++ b/UoFiddler.Controls/UserControls/TextureControl.cs
@@ -523,6 +523,8 @@ namespace UoFiddler.Controls.UserControls
                     return;
                 }
 
+                Cursor.Current = Cursors.WaitCursor;
+
                 for (int i = 0; i < listView1.Items.Count; ++i)
                 {
                     int index = (int)listView1.Items[i].Tag;
@@ -537,6 +539,8 @@ namespace UoFiddler.Controls.UserControls
                         bit.Save(fileName, imageFormat);
                     }
                 }
+
+                Cursor.Current = Cursors.Default;
 
                 MessageBox.Show($"All textures saved to {dialog.SelectedPath}", "Saved", MessageBoxButtons.OK,
                     MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);

--- a/UoFiddler.Controls/UserControls/TextureControl.cs
+++ b/UoFiddler.Controls/UserControls/TextureControl.cs
@@ -467,7 +467,7 @@ namespace UoFiddler.Controls.UserControls
         private void ExportTextureImage(int index, ImageFormat imageFormat)
         {
             string fileExtension = Utils.GetFileExtensionFor(imageFormat);
-            string fileName = Path.Combine(Options.OutputPath, $"Texture {index}.{fileExtension}");
+            string fileName = Path.Combine(Options.OutputPath, $"Texture 0x{index:X4}.{fileExtension}");
 
             using (Bitmap bit = new Bitmap(Textures.GetTexture(index)))
             {
@@ -488,6 +488,59 @@ namespace UoFiddler.Controls.UserControls
             OnClickSearch(sender, e);
             e.SuppressKeyPress = true;
             e.Handled = true;
+        }
+
+        private void ExportAllAsBmp_Click(object sender, EventArgs e)
+        {
+            ExportAllTextures(ImageFormat.Bmp);
+        }
+
+        private void ExportAllAsTiff_Click(object sender, EventArgs e)
+        {
+            ExportAllTextures(ImageFormat.Tiff);
+        }
+
+        private void ExportAllAsJpeg_Click(object sender, EventArgs e)
+        {
+            ExportAllTextures(ImageFormat.Jpeg);
+        }
+
+        private void ExportAllAsPng_Click(object sender, EventArgs e)
+        {
+            ExportAllTextures(ImageFormat.Png);
+        }
+
+        private void ExportAllTextures(ImageFormat imageFormat)
+        {
+            string fileExtension = Utils.GetFileExtensionFor(imageFormat);
+
+            using (FolderBrowserDialog dialog = new FolderBrowserDialog())
+            {
+                dialog.Description = "Select directory";
+                dialog.ShowNewFolderButton = true;
+                if (dialog.ShowDialog() != DialogResult.OK)
+                {
+                    return;
+                }
+
+                for (int i = 0; i < listView1.Items.Count; ++i)
+                {
+                    int index = (int)listView1.Items[i].Tag;
+                    if (index < 0)
+                    {
+                        continue;
+                    }
+
+                    string fileName = Path.Combine(dialog.SelectedPath, $"Texture 0x{index:X4}.{fileExtension}");
+                    using (Bitmap bit = new Bitmap(Textures.GetTexture(index)))
+                    {
+                        bit.Save(fileName, imageFormat);
+                    }
+                }
+
+                MessageBox.Show($"All textures saved to {dialog.SelectedPath}", "Saved", MessageBoxButtons.OK,
+                    MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);
+            }
         }
     }
 }

--- a/UoFiddler.Controls/UserControls/TileDataControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/TileDataControl.Designer.cs
@@ -505,7 +505,7 @@ namespace UoFiddler.Controls.UserControls
             this.tabPageLand.Padding = new System.Windows.Forms.Padding(3);
             this.tabPageLand.Size = new System.Drawing.Size(613, 268);
             this.tabPageLand.TabIndex = 1;
-            this.tabPageLand.Text = "LandTiles";
+            this.tabPageLand.Text = "Land Tiles";
             this.tabPageLand.UseVisualStyleBackColor = true;
             // 
             // splitContainer5
@@ -569,7 +569,7 @@ namespace UoFiddler.Controls.UserControls
             // 
             this.selectInLandtilesToolStripMenuItem.Name = "selectInLandtilesToolStripMenuItem";
             this.selectInLandtilesToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.selectInLandtilesToolStripMenuItem.Text = "Select In Landtiles tab";
+            this.selectInLandtilesToolStripMenuItem.Text = "Select In Land Tiles tab";
             this.selectInLandtilesToolStripMenuItem.Click += new System.EventHandler(this.OnClickSelectInLandTiles);
             // 
             // selToolStripMenuItem
@@ -780,7 +780,7 @@ namespace UoFiddler.Controls.UserControls
             this.splitter1.UseAnimations = false;
             this.splitter1.VisualStyle = UoFiddler.Controls.UserControls.VisualStyles.DoubleDots;
             // 
-            // TileDatas
+            // TileDataControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;

--- a/UoFiddler.Controls/UserControls/TileDataControl.resx
+++ b/UoFiddler.Controls/UserControls/TileDataControl.resx
@@ -117,11 +117,11 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <metadata name="contextMenuStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>162, 17</value>
+  </metadata>
+  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
   <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>307, 17</value>

--- a/UoFiddler.Controls/UserControls/TileView/CacheItemsEventHandler.cs
+++ b/UoFiddler.Controls/UserControls/TileView/CacheItemsEventHandler.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace UoFiddler.Controls.UserControls.TileView
+{
+    public class CacheItemEventArgs : EventArgs
+    {
+        public CacheItemEventArgs(List<int> indices)
+        {
+            Indices = indices;
+        }
+
+        public List<int> Indices { get; }
+
+        public bool Success;
+    }
+
+}

--- a/UoFiddler.Controls/UserControls/TileView/IndicesCollection.cs
+++ b/UoFiddler.Controls/UserControls/TileView/IndicesCollection.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace UoFiddler.Controls.UserControls.TileView
+{
+    public class IndicesCollection : IList<int>
+    {
+        private readonly List<int> _internal = new List<int>();
+
+        public int IndexOf(int item)
+        {
+            return _internal.IndexOf(item);
+        }
+
+        public void Add(int item)
+        {
+            _internal.Add(item);
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, new List<int>() { item }));
+        }
+
+        public void Insert(int index, int item)
+        {
+            _internal.Insert(index, item);
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, new List<int>() { item }));
+        }
+
+        public int this[int index]
+        {
+            get => _internal[index];
+            set
+            {
+                _internal[index] = value;
+                CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, new List<int>() { value }));
+            }
+        }
+
+        public void Clear()
+        {
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, _internal));
+
+            _internal.Clear();
+        }
+
+        public bool Contains(int item)
+        {
+            return _internal.Contains(item);
+        }
+
+        public void CopyTo(int[] array, int arrayIndex)
+        {
+            _internal.CopyTo(array, arrayIndex);
+        }
+
+        public int Count => _internal.Count;
+
+        public bool IsReadOnly => false;
+
+        public void RemoveAt(int index)
+        {
+            if (index < 0 || index >= _internal.Count)
+                throw new IndexOutOfRangeException("Index out of range");
+
+            int item = this[index];
+
+            _internal.RemoveAt(index);
+
+            CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, new List<int>() { item }));
+        }
+
+        public bool Remove(int item)
+        {
+            bool removed = _internal.Remove(item);
+
+            if (removed)
+                CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, new List<int>() { item }));
+
+            return removed;
+        }
+
+        public IEnumerator<int> GetEnumerator()
+        {
+            return _internal.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return _internal.GetEnumerator();
+        }
+
+        public event EventHandler<NotifyCollectionChangedEventArgs> CollectionChanged;
+
+        public class NotifyCollectionChangedEventArgs : EventArgs
+        {
+            public NotifyCollectionChangedAction Action;
+            public List<int> ItemsChanged;
+
+            /// <summary>
+            /// Initializes NotifyCollectionChangedEventArgs on Add or Remove action with list of changed items
+            /// </summary>
+            /// <param name="action"></param>
+            /// <param name="itemsChanged"></param>
+            public NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction action, List<int> itemsChanged)
+            {
+                Action = action;
+                ItemsChanged = itemsChanged;
+            }
+        }
+
+        public enum NotifyCollectionChangedAction
+        {
+            Add,
+            Remove
+        }
+    }
+}

--- a/UoFiddler.Controls/UserControls/TileView/TileViewControl.cs
+++ b/UoFiddler.Controls/UserControls/TileView/TileViewControl.cs
@@ -1,0 +1,699 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace UoFiddler.Controls.UserControls.TileView
+{
+    [Browsable(true)]
+    public class TileViewControl : ScrollableControl
+    {
+        private int _itemsPerRow;
+
+        /// <summary>
+        /// Backwards compatibility with ListView ItemSelectionChanged event. Warning: Have a high chance to be changed in future.
+        /// </summary>
+        public event EventHandler<ListViewItemSelectionChangedEventArgs> ItemSelectionChanged;
+
+        public event EventHandler<ListViewFocusedItemSelectionChangedEventArgs> FocusSelectionChanged;
+
+        public IndicesCollection SelectedIndices = new IndicesCollection();
+
+        private int _focusIndex = -1;
+
+        /// <summary>
+        /// Get or Set SelectedIndex, setting this property to -1 will remove selection, -2 is reserved for "do nothing".
+        /// </summary>
+        public int FocusIndex
+        {
+            get => _focusIndex;
+            set
+            {
+                if (value >= VirtualListSize)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value));
+                }
+
+                if (_focusIndex == value)
+                {
+                    return;
+                }
+
+                if (value == -2)
+                {
+                    return;
+                }
+
+                int oldIndex = _focusIndex;
+
+                _focusIndex = value;
+
+                if (!_multiSelect)
+                {
+                    SelectIndex(value);
+                }
+
+                if (oldIndex != -1)
+                {
+                    RedrawItem(oldIndex);
+                }
+
+                FocusSelectionChanged?.Invoke(this, new ListViewFocusedItemSelectionChangedEventArgs(_focusIndex, true));
+
+                if (value == -1)
+                {
+                    return;
+                }
+
+                RedrawItem(value);
+                ScrollToItem(value);
+            }
+        }
+
+        /// <summary>
+        /// Scroll to item if it's out of view
+        /// </summary>
+        /// <param name="value">Item index</param>
+        private void ScrollToItem(int value)
+        {
+            Point p = GetItemLocation(value);
+
+            int y = -AutoScrollPosition.Y;
+            if (y == p.Y)
+            {
+                return;
+            }
+
+            if (y > p.Y)
+            {
+                AutoScrollPosition = new Point(0, p.Y);
+            }
+            else if (p.Y - y + TotalTileSize.Height > Height)
+            {
+                //TODO: correct slight mispositioned while this.Height (control) is less than m_TotalTileSize.Height
+                AutoScrollPosition = new Point(0, p.Y + TotalTileSize.Height - Height);
+            }
+        }
+
+        private bool _multiSelect;
+
+        [Browsable(true)]
+        public bool MultiSelect
+        {
+            get => _multiSelect;
+            set
+            {
+                _multiSelect = value;
+                Invalidate(); // TODO: maybe just visible area? or selected items redraw?
+            }
+        }
+
+        private int _virtualListSize;
+
+        /// <summary>
+        /// Get or Set amount of Items to be displayed.
+        /// </summary>
+        public int VirtualListSize
+        {
+            get => _virtualListSize;
+            set
+            {
+                _virtualListSize = value;
+
+                if (_focusIndex >= _virtualListSize)
+                {
+                    FocusIndex = -1; // we are setting public one so all events will be triggered properly
+                }
+
+                if (Size.IsEmpty)
+                {
+                    return;
+                }
+
+                SelectedIndices.Clear();
+                _cachedIndices.Clear();
+                UpdateAutoScrollSize();
+            }
+        }
+
+        /// <summary>
+        /// This function is being called whenever anything related to size of Tile or VirtualListSize is changed. It also updated ItemsPerRow value.
+        /// </summary>
+        /// <returns></returns>
+        private void UpdateAutoScrollSize()
+        {
+            if (_virtualListSize == 0 || Size.IsEmpty)
+            {
+                return;
+            }
+
+            _itemsPerRow = DisplayRectangle.Width / TotalTileSize.Width;
+
+            //if (m_ItemsPerRow < 1) m_ItemsPerRow = 1; // bug from line above, but could not reproduce
+
+            // for now we are supporting only Vertical scrolling.
+            AutoScrollMinSize = new Size(0, DivUp(_virtualListSize, _itemsPerRow) * TotalTileSize.Height);
+
+            Invalidate();
+        }
+
+        private List<int> _cachedIndices = new List<int>();
+
+        //http://stackoverflow.com/questions/921180/how-can-i-ensure-that-a-division-of-integers-is-always-rounded-up/924160#924160
+        private static int DivUp(int a, int b)
+        {
+            int r = a / b;
+            if (((a ^ b) >= 0) && (a % b != 0))
+            {
+                r++;
+            }
+
+            return r;
+        }
+
+        public Size TotalTileSize =>
+            new Size(
+                _tileSize.Width + _tileMargin.Horizontal + _tilePadding.Horizontal +
+                (int)(_tileBorder.Width * 2),
+                _tileSize.Height + _tileMargin.Vertical + _tilePadding.Vertical +
+                (int)(_tileBorder.Width * 2));
+
+        private Size _tileSize = new Size(256, 256);
+
+        public Size TileSize
+        {
+            get => _tileSize;
+            set
+            {
+                _tileSize = value;
+                UpdateAutoScrollSize();
+            }
+        }
+
+        private Padding _tileMargin = new Padding(2, 2, 2, 2); // external
+
+        public Padding TileMargin
+        {
+            get => _tileMargin;
+            set
+            {
+                _tileMargin = value;
+                UpdateAutoScrollSize();
+            }
+        }
+
+        private Padding _tilePadding = new Padding(2, 2, 2, 2);
+
+        public Padding TilePadding
+        {
+            get => _tilePadding;
+            set
+            {
+                _tilePadding = value;
+                UpdateAutoScrollSize();
+            }
+        }
+
+        private readonly Pen _tileBorder = new Pen(Brushes.Black, 1.0f);
+
+        public float TileBorderWidth
+        {
+            get => _tileBorder.Width;
+            set
+            {
+                _tileBorder.Width = value;
+                UpdateAutoScrollSize();
+            }
+        }
+
+        [Browsable(true)]
+        public Color TileBorderColor
+        {
+            get => _tileBorder.Color;
+            set
+            {
+                _tileBorder.Color = value;
+                if (_tileBorder.Width > 0)
+                {
+                    Invalidate();
+                }
+            }
+        }
+
+        private const double _defaultOpacityValue = 0.6;
+        private double _tileHighlightOpacity = _defaultOpacityValue;
+
+        [Browsable(true)]
+        [Description("Opacity value for highlight color. Allowed values 0-100% (default 60%).")]
+        [TypeConverter(typeof(OpacityConverter))]
+        [DefaultValue(_defaultOpacityValue)]
+        public double TileHighLightOpacity
+        {
+            get => _tileHighlightOpacity;
+            set
+            {
+                _tileHighlightOpacity = value;
+
+                if (SelectedIndices.Count > 0)
+                {
+                    RedrawItems(SelectedIndices.ToList());
+                }
+            }
+        }
+
+        private Color _tileHighlightColor = SystemColors.Highlight;
+
+        /// <summary>
+        /// Color of selected item background
+        /// </summary>
+        [Browsable(true)]
+        public Color TileHighlightColor
+        {
+            get => _tileHighlightColor;
+            set
+            {
+                _tileHighlightColor = value;
+
+                if (SelectedIndices.Count > 0)
+                {
+                    RedrawItems(SelectedIndices.ToList());
+                }
+            }
+        }
+
+        private Color _tileBackgroundColor = SystemColors.Window;
+        /// <summary>
+        /// Color of selected item background
+        /// </summary>
+        [Browsable(true)]
+        public Color TileBackgroundColor
+        {
+            get => _tileBackgroundColor;
+            set
+            {
+                _tileBackgroundColor = value;
+                Invalidate();
+            }
+        }
+
+        public TileViewControl()
+        {
+            SetStyle(ControlStyles.UserMouse, true); // to make control focusable
+            SetStyle(ControlStyles.AllPaintingInWmPaint | ControlStyles.OptimizedDoubleBuffer, true);
+
+            ResizeRedraw = true;
+
+            SizeChanged += (o, e) => UpdateAutoScrollSize();
+
+            MouseDown += (o, e) =>
+            {
+                int idx = GetIndexAtLocation(e.Location);
+
+                FocusIndex = idx;
+
+                if (idx != -2 && e.Button == MouseButtons.Left) // no Tile at given location
+                {
+                    SelectIndex(idx);
+                }
+            };
+
+            SelectedIndices.CollectionChanged += (o, e) =>
+            {
+                if (e.ItemsChanged.Count == 0)
+                {
+                    return;
+                }
+
+                RedrawItems(e.ItemsChanged);
+
+                if (ItemSelectionChanged == null)
+                {
+                    return;
+                }
+
+                foreach (Delegate del in ItemSelectionChanged.GetInvocationList())
+                {
+                    del.DynamicInvoke(this,
+                        new ListViewItemSelectionChangedEventArgs(null, e.ItemsChanged[0],
+                            e.Action == IndicesCollection.NotifyCollectionChangedAction.Add));
+                }
+            };
+        }
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            // Handling control keys so we can change focus with keys
+
+            if (keyData == Keys.Home || keyData == Keys.End)
+            {
+                if (_focusIndex > -1)
+                {
+                    switch (keyData)
+                    {
+                        case Keys.Home:
+                            ScrollToItem(0);
+                            FocusIndex = GetVisibleIndices(Bounds)[0];
+                            break;
+                        case Keys.End:
+                            var lastItem = VirtualListSize - 1;
+                            ScrollToItem(lastItem);
+                            FocusIndex = lastItem;
+                            break;
+                    }
+                }
+                else if (VirtualListSize > 0) // if there's no focus, focus on first item visible index
+                {
+                    FocusIndex = GetVisibleIndices(Bounds)[0];
+                }
+            }
+
+            if (keyData == Keys.PageUp || keyData == Keys.PageDown)
+            {
+                if (_focusIndex > -1)
+                {
+                    int newFocusIndex = _focusIndex;
+                    int visibleRows = GetVisibleIndices(Bounds).Count / _itemsPerRow;
+                    switch (keyData)
+                    {
+                        case Keys.PageUp:
+                            {
+                                if (newFocusIndex - _itemsPerRow > -1)
+                                {
+                                    newFocusIndex -= _itemsPerRow * (visibleRows - 1);
+                                }
+                                break;
+                            }
+                        case Keys.PageDown:
+                            {
+                                if (newFocusIndex + _itemsPerRow < _virtualListSize)
+                                {
+                                    newFocusIndex += _itemsPerRow * (visibleRows - 1);
+                                }
+                                break;
+                            }
+                    }
+
+                    FocusIndex = newFocusIndex < VirtualListSize ? newFocusIndex : VirtualListSize - 1;
+                }
+                else if (VirtualListSize > 0) // if there's no focus, focus on first item visible index
+                {
+                    FocusIndex = GetVisibleIndices(Bounds)[0];
+                }
+            }
+            else if (keyData == Keys.Up || keyData == Keys.Down || keyData == Keys.Left || keyData == Keys.Right)
+            {
+                if (_focusIndex > -1)
+                {
+                    int newFocusIndex = _focusIndex;
+                    switch (keyData)
+                    {
+                        case Keys.Left:
+                            if (newFocusIndex - 1 > -1)
+                            {
+                                --newFocusIndex;
+                            }
+                            break;
+                        case Keys.Right:
+                            if (newFocusIndex + 1 < _virtualListSize)
+                            {
+                                ++newFocusIndex;
+                            }
+                            break;
+                        case Keys.Up:
+                            if (newFocusIndex - _itemsPerRow > -1)
+                            {
+                                newFocusIndex -= _itemsPerRow;
+                            }
+                            break;
+                        case Keys.Down:
+                            if (newFocusIndex + _itemsPerRow < _virtualListSize)
+                            {
+                                newFocusIndex += _itemsPerRow;
+                            }
+                            break;
+                    }
+
+                    FocusIndex = newFocusIndex;
+                }
+                else if (VirtualListSize > 0) // if there's no focus, focus on first item visible index
+                {
+                    FocusIndex = GetVisibleIndices(Bounds)[0];
+                }
+            }
+            else
+            {
+                if (keyData == Keys.Space || ((keyData & Keys.Space) == Keys.Space && ((keyData & Keys.Shift) == Keys.Shift || (keyData & Keys.Control) == Keys.Control)))
+                {
+                    if (_focusIndex >= 0)
+                    {
+                        SelectIndex(_focusIndex);
+                    }
+                }
+            }
+
+            return base.ProcessCmdKey(ref msg, keyData);
+        }
+
+        private void SelectIndex(int index)
+        {
+            switch (ModifierKeys)
+            {
+                case Keys.Control:
+                    if (_multiSelect)
+                    {
+                        if (SelectedIndices.Contains(index))
+                        {
+                            SelectedIndices.Remove(index);
+                        }
+                        else
+                        {
+                            SelectedIndices.Add(index);
+                        }
+                    }
+                    else
+                    {
+                        if (!SelectedIndices.Contains(index))
+                        {
+                            SelectedIndices.Clear();
+                            SelectedIndices.Add(index);
+                        }
+                    }
+
+                    break;
+                default:
+                    if (!SelectedIndices.Contains(index))
+                    {
+                        SelectedIndices.Clear();
+                        SelectedIndices.Add(index);
+                    }
+
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Redraw Tile with given index
+        /// </summary>
+        /// <param name="index"></param>
+        public void RedrawItem(int index)
+        {
+            Point p = new Point(index % _itemsPerRow * TotalTileSize.Width + AutoScrollPosition.X, index / _itemsPerRow * TotalTileSize.Height + AutoScrollPosition.Y);
+            Invalidate(new Rectangle(p, TotalTileSize));
+        }
+
+        public void RedrawItems(List<int> indices)
+        {
+            indices.ForEach(RedrawItem);
+        }
+
+        private Point GetItemLocation(int index)
+        {
+            return new Point(index % _itemsPerRow * TotalTileSize.Width, index / _itemsPerRow * TotalTileSize.Height);
+        }
+
+        /// <summary>
+        /// Find index of Tile for given location.
+        /// </summary>
+        /// <param name="location"></param>
+        /// <returns>Index of Tile in location. Return -2 if no Tile at given location.</returns>
+        public int GetIndexAtLocation(Point location)
+        {
+            int line = (location.Y + -AutoScrollPosition.Y) / TotalTileSize.Height;
+            int row = (location.X + -AutoScrollPosition.X) / TotalTileSize.Width;
+            if (DivUp(location.X, TotalTileSize.Width) > _itemsPerRow)
+            {
+                return -2;
+            }
+
+            int r = (line * _itemsPerRow + row);
+            if (r >= VirtualListSize)
+            {
+                return -2;
+            }
+
+            return r;
+        }
+
+        /// <summary>
+        /// Get list of indices of Tiles for given rectangle.
+        /// </summary>
+        /// <param name="rect"></param>
+        /// <returns>List of indices. Indices may have discontinuities.</returns>
+        private List<int> GetVisibleIndices(RectangleF rect)
+        {
+            int line = (int)rect.Y / TotalTileSize.Height;
+            int row = (int)rect.X / TotalTileSize.Width;
+
+            //int rem;
+            //Math.DivRem(-this.AutoScrollPosition.Y, m_TotalTileSize.Height, out rem);
+            //rem = (-this.AutoScrollPosition.Y + m_TotalTileSize.Height) - m_TotalTileSize.Height * line;
+
+            int lines = ((int)(rect.Y + rect.Height - 1) / TotalTileSize.Height) - ((int)rect.Y / TotalTileSize.Height) + 1;
+            int rows = (int)rect.Width / TotalTileSize.Width;
+
+            if (lines == 0)
+            {
+                lines = 1; // Draw at last one item in visible area.
+            }
+
+            if (rows == 0)
+            {
+                rows = 1;
+            }
+
+            List<int> indices = new List<int>();
+            for (int l = line; l < line + lines; l++)
+            {
+                for (int r = row; r < row + rows; r++)
+                {
+                    var i = l * _itemsPerRow + r;
+                    if (i >= VirtualListSize)
+                    {
+                        break;
+                    }
+
+                    if (indices.Contains(i))
+                    {
+                        continue;
+                    }
+
+                    indices.Add(i);
+                }
+            }
+
+            return indices;
+        }
+
+        /// <summary>
+        /// Backwards compatibility with ListView DrawItem event. Warning: Have a high chance to be changed in future.
+        /// </summary>
+        public event EventHandler<DrawTileListItemEventArgs> DrawItem;
+
+        public event EventHandler<CacheItemEventArgs> CacheItems;
+
+        protected override void OnPaint(PaintEventArgs e)
+        {
+            base.OnPaint(e);
+
+            e.Graphics.TranslateTransform(AutoScrollPosition.X, AutoScrollPosition.Y);
+
+            List<int> visibleIndices = GetVisibleIndices(e.Graphics.VisibleClipBounds);
+
+            if (CacheItems != null)
+            {
+                Rectangle rect = Bounds;
+                rect.Offset(-AutoScrollPosition.X, -AutoScrollPosition.Y);
+
+                List<int> allIndices = GetVisibleIndices(rect);
+                if (allIndices.Count > 0 && (_cachedIndices.Count == 0 || _cachedIndices.Count < allIndices.Count || (_cachedIndices[0] > allIndices[0] || _cachedIndices[_cachedIndices.Count - 1] < allIndices[allIndices.Count - 1])))
+                {
+                    CacheItemEventArgs ne = new CacheItemEventArgs(allIndices);
+
+                    CacheItems?.Invoke(this, ne);
+
+                    if (ne.Success)
+                    {
+                        _cachedIndices = allIndices;
+                    }
+                }
+            }
+
+            foreach (int i in visibleIndices)
+            {
+                if (i >= VirtualListSize)
+                {
+                    throw new ArgumentException("Index out of range", nameof(i));
+                }
+
+                Size single = new Size(1, 1);
+                Size borderSize = new Size((int)_tileBorder.Width * 2, (int)_tileBorder.Width * 2); // border size
+
+                Point itemLocation = GetItemLocation(i);
+
+                Point marginPoint = new Point(itemLocation.X + _tileMargin.Left, itemLocation.Y + _tileMargin.Top); // margin point
+                Point borderPoint = new Point(marginPoint.X + (int)_tileBorder.Width, marginPoint.Y + (int)_tileBorder.Width); // bordered point
+                Point paddedPoint = new Point(borderPoint.X + _tilePadding.Left, borderPoint.Y + _tilePadding.Top); // padded point
+
+                Rectangle marginRec = new Rectangle(marginPoint, _tileSize + _tilePadding.Size + borderSize);
+                Rectangle borderRec = new Rectangle(borderPoint, _tileSize + _tilePadding.Size);
+                Rectangle paddedRec = new Rectangle(paddedPoint, _tileSize);
+
+                if (DrawItem != null)
+                {
+                    DrawItem(this, new DrawTileListItemEventArgs(e.Graphics, Font, borderRec, i, _focusIndex == i ? DrawItemState.Selected : DrawItemState.None));
+                }
+                else
+                {
+                    using (var brush = new SolidBrush(_tileBackgroundColor))
+                    {
+                        e.Graphics.FillRectangle(brush, paddedRec); // tile itself
+                    }
+
+                    // TODO: Add text drawing?
+                }
+
+                if (SelectedIndices.Contains(i))
+                {
+                    using (var brush = new SolidBrush(Color.FromArgb((int)(_tileHighlightOpacity * 255), _tileHighlightColor)))
+                    {
+                        e.Graphics.FillRectangle(brush, marginRec);
+                    }
+                }
+
+                if (_tileBorder.Width > 0)
+                {
+                    e.Graphics.DrawRectangle(_tileBorder, new Rectangle(marginRec.Location, marginRec.Size - single));
+                }
+
+                // not sure yet on should it be in DrawItem or here...
+                if (_focusIndex == i)
+                {
+                    Rectangle focusRec = new Rectangle(marginPoint + single, _tileSize + _tilePadding.Size);
+                    ControlPaint.DrawFocusRectangle(e.Graphics, focusRec);
+                }
+            }
+        }
+
+        public class ListViewFocusedItemSelectionChangedEventArgs : EventArgs
+        {
+            public int FocusedItemIndex { get; }
+            public bool IsFocused { get; }
+
+            public ListViewFocusedItemSelectionChangedEventArgs(int focusedItemIndex, bool isFocused)
+            {
+                FocusedItemIndex = focusedItemIndex;
+                IsFocused = isFocused;
+            }
+        }
+
+        public class DrawTileListItemEventArgs : DrawItemEventArgs
+        {
+            public DrawTileListItemEventArgs(Graphics graphics, Font font, Rectangle rect, int index,
+                DrawItemState state) : base(graphics, font, rect, index, state)
+            {
+            }
+        }
+    }
+}

--- a/UoFiddler.Plugin.Compare/Classes/SecondArt.cs
+++ b/UoFiddler.Plugin.Compare/Classes/SecondArt.cs
@@ -21,16 +21,19 @@ namespace UoFiddler.Plugin.Compare.Classes
 
         public static int GetMaxItemId()
         {
+            // High Seas
             if (GetIdxLength() >= 0x13FDC)
             {
-                return 0xFFFF;
+                return 0xFFDC;
             }
 
+            // Stygian Abyss
             if (GetIdxLength() == 0xC000)
             {
                 return 0x7FFF;
             }
 
+            // ML and older
             return 0x3FFF;
         }
 

--- a/UoFiddler.Plugin.ExamplePlugin/ExamplePluginBase.cs
+++ b/UoFiddler.Plugin.ExamplePlugin/ExamplePluginBase.cs
@@ -174,44 +174,41 @@ namespace UoFiddler.Plugin.ExamplePlugin
 
         private void ExportToItemDescClicked(object sender, EventArgs e)
         {
+            var selectedArtIds = new List<int>();
+
             if (Options.DesignAlternative)
             {
-                ExportSingleItem(Host.GetSelectedItemShowAlternative());
-            }
-            else
-            {
-                ExportAllSelectedItems(Host.GetItemShowListView());
-            }
-        }
+                var itemShowAltControl = Host.GetItemShowAltControl();
+                var itemShowAltTileView = Host.GetItemShowAltTileView();
 
-        private static void ExportAllSelectedItems(ListView itemShowListView)
-        {
-            ListView.SelectedListViewItemCollection selectedItems = itemShowListView.SelectedItems;
-            if (selectedItems.Count <= 0)
-            {
-                return;
-            }
-
-            string path = Options.OutputPath;
-            string fileName = Path.Combine(path, _itemDescFileName);
-
-            using (StreamWriter streamWriter = new StreamWriter(new FileStream(fileName, FileMode.Append, FileAccess.Write), Encoding.GetEncoding(1252)))
-            {
-                foreach (ListViewItem item in selectedItems)
+                foreach (var item in itemShowAltTileView.SelectedIndices)
                 {
-                    int itemId = (int)item.Tag;
-
-                    if (Art.IsValidStatic(itemId))
+                    var graphic = itemShowAltControl.ItemList[item];
+                    if (Art.IsValidStatic(graphic))
                     {
-                        streamWriter.WriteLine(GetItemDescEntry(itemId));
+                        selectedArtIds.Add(graphic);
                     }
                 }
             }
+            else
+            {
+                var itemShowListView = Host.GetItemShowListView();
+                foreach (ListViewItem item in itemShowListView.SelectedItems)
+                {
+                    int graphic = (int)item.Tag;
+                    if (Art.IsValidStatic(graphic))
+                    {
+                        selectedArtIds.Add(graphic);
+                    }
+                }
+            }
+
+            ExportAllItems(selectedArtIds);
         }
 
-        private static void ExportSingleItem(int itemId)
+        private static void ExportAllItems(ICollection<int> items)
         {
-            if (itemId <= -1 || !Art.IsValidStatic(itemId))
+            if (items.Count == 0)
             {
                 return;
             }
@@ -221,7 +218,10 @@ namespace UoFiddler.Plugin.ExamplePlugin
 
             using (StreamWriter streamWriter = new StreamWriter(new FileStream(fileName, FileMode.Append, FileAccess.Write), Encoding.GetEncoding(1252)))
             {
-                streamWriter.WriteLine(GetItemDescEntry(itemId));
+                foreach (var item in items)
+                {
+                    streamWriter.WriteLine(GetItemDescEntry(item));
+                }
             }
         }
 

--- a/UoFiddler.Plugin.SendItem/SendItem.cs
+++ b/UoFiddler.Plugin.SendItem/SendItem.cs
@@ -18,6 +18,7 @@ using UoFiddler.Controls.Classes;
 using UoFiddler.Controls.Plugin;
 using UoFiddler.Controls.Plugin.Interfaces;
 using UoFiddler.Controls.UserControls;
+using UoFiddler.Controls.UserControls.TileView;
 using UoFiddler.Plugin.SendItem.Forms;
 using Events = UoFiddler.Controls.Plugin.PluginEvents;
 
@@ -117,16 +118,16 @@ namespace UoFiddler.Plugin.SendItem
             if (Options.DesignAlternative)
             {
                 ItemShowAlternativeControl itemShowAltControl = Host.GetItemShowAltControl();
-                PictureBox itemShowAltPictureBox = Host.GetItemShowAltPictureBox();
+                TileViewControl itemShowTileView = Host.GetItemShowAltTileView();
                 if (value)
                 {
-                    itemShowAltPictureBox.MouseDoubleClick -= itemShowAltControl.OnMouseDoubleClick;
-                    itemShowAltPictureBox.MouseDoubleClick += PlugOnDoubleClick;
+                    itemShowTileView.MouseDoubleClick -= itemShowAltControl.ItemsTileView_MouseDoubleClick;
+                    itemShowTileView.MouseDoubleClick += PlugOnDoubleClick;
                 }
                 else if (!init)
                 {
-                    itemShowAltPictureBox.MouseDoubleClick -= PlugOnDoubleClick;
-                    itemShowAltPictureBox.MouseDoubleClick += itemShowAltControl.OnMouseDoubleClick;
+                    itemShowTileView.MouseDoubleClick -= PlugOnDoubleClick;
+                    itemShowTileView.MouseDoubleClick += itemShowAltControl.ItemsTileView_MouseDoubleClick;
                 }
             }
             else

--- a/UoFiddler/Forms/AboutBoxForm.resx
+++ b/UoFiddler/Forms/AboutBoxForm.resx
@@ -118,7 +118,14 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="richTextBox1.Text" xml:space="preserve">
-    <value>Version 4.9.5
+    <value>Version 4.9.6
+Added new tile view control to Items, Land Tiles, Textures and Fonts. Rendering should be now smooth and fast. To use new control Alternative design mode in settings needs to be checked (thanks goes to control author Anton a.k.a 0xE1 https://github.com/0xE1/Managed-TileView and deccer for finding it).
+Added Export all... option to Textures tab.
+Changed how fonts are loaded. It should be faster now. By default when you enter Fonts tab it will load ASCII fonts only. Unicode ones are loaded after selecting checkbox.
+Fixed AnimData Save button.
+Fixed default text on Speech tab.
+
+Version 4.9.5
 Fixed rare hang when selecting tiles in Items/LandTiles tab from other tabs. 
 Fixed crash when using context menu in tiledata item list.
 Fixed multi design saving for UO architect. File extension changed to .uoa.txt to indicate that it is text format and not binary one. Updated import options for UO Architect txt files.

--- a/UoFiddler/Forms/MainForm.Designer.cs
+++ b/UoFiddler/Forms/MainForm.Designer.cs
@@ -297,7 +297,7 @@ namespace UoFiddler.Forms
             this.LandTilesTab.Size = new System.Drawing.Size(776, 510);
             this.LandTilesTab.TabIndex = 3;
             this.LandTilesTab.Tag = 4;
-            this.LandTilesTab.Text = "LandTiles";
+            this.LandTilesTab.Text = "Land Tiles";
             this.LandTilesTab.UseVisualStyleBackColor = true;
             // 
             // landTilesControl
@@ -318,7 +318,7 @@ namespace UoFiddler.Forms
             this.TextureTab.Size = new System.Drawing.Size(776, 510);
             this.TextureTab.TabIndex = 11;
             this.TextureTab.Tag = 5;
-            this.TextureTab.Text = "Texture";
+            this.TextureTab.Text = "Textures";
             this.TextureTab.UseVisualStyleBackColor = true;
             // 
             // textureControl

--- a/UoFiddler/Forms/OptionsForm.Designer.cs
+++ b/UoFiddler/Forms/OptionsForm.Designer.cs
@@ -123,7 +123,12 @@ namespace UoFiddler.Forms
             // 
             this.numericUpDownItemSizeHeight.Location = new System.Drawing.Point(118, 19);
             this.numericUpDownItemSizeHeight.Maximum = new decimal(new int[] {
-            1000,
+            512,
+            0,
+            0,
+            0});
+            this.numericUpDownItemSizeHeight.Minimum = new decimal(new int[] {
+            48,
             0,
             0,
             0});
@@ -131,6 +136,11 @@ namespace UoFiddler.Forms
             this.numericUpDownItemSizeHeight.Size = new System.Drawing.Size(50, 20);
             this.numericUpDownItemSizeHeight.TabIndex = 3;
             this.toolTip1.SetToolTip(this.numericUpDownItemSizeHeight, "Height");
+            this.numericUpDownItemSizeHeight.Value = new decimal(new int[] {
+            96,
+            0,
+            0,
+            0});
             // 
             // checkBoxItemClip
             // 
@@ -156,10 +166,25 @@ namespace UoFiddler.Forms
             // numericUpDownItemSizeWidth
             // 
             this.numericUpDownItemSizeWidth.Location = new System.Drawing.Point(62, 19);
+            this.numericUpDownItemSizeWidth.Maximum = new decimal(new int[] {
+            512,
+            0,
+            0,
+            0});
+            this.numericUpDownItemSizeWidth.Minimum = new decimal(new int[] {
+            48,
+            0,
+            0,
+            0});
             this.numericUpDownItemSizeWidth.Name = "numericUpDownItemSizeWidth";
             this.numericUpDownItemSizeWidth.Size = new System.Drawing.Size(50, 20);
             this.numericUpDownItemSizeWidth.TabIndex = 0;
             this.toolTip1.SetToolTip(this.numericUpDownItemSizeWidth, "Width");
+            this.numericUpDownItemSizeWidth.Value = new decimal(new int[] {
+            96,
+            0,
+            0,
+            0});
             // 
             // checkBoxCacheData
             // 

--- a/UoFiddler/UoFiddler.csproj
+++ b/UoFiddler/UoFiddler.csproj
@@ -8,9 +8,9 @@
 		<AssemblyTitle>UoFiddler</AssemblyTitle>
 		<Product>UoFiddler</Product>
 		<Copyright>Copyright © 2020</Copyright>
-		<AssemblyVersion>4.9.5</AssemblyVersion>
-		<FileVersion>4.9.5</FileVersion>
-		<Version>4.9.5</Version>
+		<AssemblyVersion>4.9.6</AssemblyVersion>
+		<FileVersion>4.9.6</FileVersion>
+		<Version>4.9.6</Version>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 		<DebugType>portable</DebugType>


### PR DESCRIPTION
**New tile view control for Items, Land Tiles, Textures and Fonts tabs.** 
- Works when "Alternative Design" in Settings is checked. 
- It is much smoother then previous implementations.
- All existing functionalities should be in place.
- PageUp/PageDown jumps by one screen and Home/End to start or end of list.
- At some point this will probably be only one control used in tabs.

**Other changes**
- "Export all..." option added to Textures tab.
- Faster Fonts tab loading by turning off reading of Unicode fonts by default.
- Fixed Save button in AnimData tab.
- Fixed clearing of default text in Speech tab.
- Few minor changes to tab titles and captions.