### PR TITLE
New functions in Land Tiles, Gumps, Texture and Tiledata tabs

### DIFF
--- a/Ultima/Textures.cs
+++ b/Ultima/Textures.cs
@@ -68,6 +68,8 @@ namespace Ultima
         /// <returns></returns>
         public static bool TestTexture(int index)
         {
+            index &= 0x3FFF;
+
             if (_removed[index])
             {
                 return false;

--- a/UoFiddler.Controls/UserControls/GumpControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/GumpControl.Designer.cs
@@ -74,6 +74,8 @@ namespace UoFiddler.Controls.UserControls
             this.Preload = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
             this.PreLoader = new System.ComponentModel.BackgroundWorker();
+            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            this.InsertStartingFromTb = new System.Windows.Forms.ToolStripTextBox();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
             this.splitContainer1.Panel1.SuspendLayout();
             this.splitContainer1.Panel2.SuspendLayout();
@@ -130,10 +132,11 @@ namespace UoFiddler.Controls.UserControls
             this.replaceGumpToolStripMenuItem,
             this.removeToolStripMenuItem,
             this.insertToolStripMenuItem,
+            this.toolStripMenuItem1,
             this.toolStripSeparator1,
             this.saveToolStripMenuItem});
             this.contextMenuStrip1.Name = "contextMenuStrip1";
-            this.contextMenuStrip1.Size = new System.Drawing.Size(190, 170);
+            this.contextMenuStrip1.Size = new System.Drawing.Size(190, 214);
             // 
             // extractImageToolStripMenuItem
             // 
@@ -389,7 +392,22 @@ namespace UoFiddler.Controls.UserControls
             this.PreLoader.ProgressChanged += new System.ComponentModel.ProgressChangedEventHandler(this.PreLoaderProgressChanged);
             this.PreLoader.RunWorkerCompleted += new System.ComponentModel.RunWorkerCompletedEventHandler(this.PreLoaderCompleted);
             // 
-            // Gump
+            // toolStripMenuItem1
+            // 
+            this.toolStripMenuItem1.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.InsertStartingFromTb});
+            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+            this.toolStripMenuItem1.Size = new System.Drawing.Size(189, 22);
+            this.toolStripMenuItem1.Text = "Insert Starting From";
+            // 
+            // InsertStartingFromTb
+            // 
+            this.InsertStartingFromTb.Font = new System.Drawing.Font("Segoe UI", 9F);
+            this.InsertStartingFromTb.Name = "InsertStartingFromTb";
+            this.InsertStartingFromTb.Size = new System.Drawing.Size(100, 23);
+            this.InsertStartingFromTb.KeyDown += new System.Windows.Forms.KeyEventHandler(this.InsertStartingFromTb_KeyDown);
+            // 
+            // GumpControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
@@ -449,5 +467,8 @@ namespace UoFiddler.Controls.UserControls
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
 
         #endregion
+
+        private System.Windows.Forms.ToolStripMenuItem toolStripMenuItem1;
+        private System.Windows.Forms.ToolStripTextBox InsertStartingFromTb;
     }
 }

--- a/UoFiddler.Controls/UserControls/GumpControl.cs
+++ b/UoFiddler.Controls/UserControls/GumpControl.cs
@@ -1,9 +1,9 @@
 /***************************************************************************
  *
  * $Author: Turley
- * 
+ *
  * "THE BEER-WARE LICENSE"
- * As long as you retain this notice you can do whatever you want with 
+ * As long as you retain this notice you can do whatever you want with
  * this stuff. If we meet some day, and you think this stuff is worth it,
  * you can buy me a beer in return.
  *
@@ -659,7 +659,7 @@ namespace UoFiddler.Controls.UserControls
                 return;
             }
 
-            _showForm = new GumpSearchForm {TopMost = true};
+            _showForm = new GumpSearchForm { TopMost = true };
             _showForm.Show();
         }
 
@@ -710,7 +710,6 @@ namespace UoFiddler.Controls.UserControls
                 return;
             }
 
-
             contextMenuStrip1.Close();
             using (OpenFileDialog dialog = new OpenFileDialog())
             {
@@ -723,25 +722,25 @@ namespace UoFiddler.Controls.UserControls
                     return;
                 }
 
-
-
                 if (CheckForIndexes(index, dialog.FileNames.Length))
                 {
-                    for(int i = 0; i < dialog.FileNames.Length; i++)
+                    for (int i = 0; i < dialog.FileNames.Length; i++)
                     {
                         var currentIdx = index + i;
                         AddSingleGump(dialog.FileNames[i], currentIdx);
                     }
                 }
-
-                
-
-                
             }
 
             Options.ChangedUltimaClass["Gumps"] = true;
         }
 
+        /// <summary>
+        /// Check if all the indexes from baseIndex to baseIndex + count are valid
+        /// </summary>
+        /// <param name="baseIndex">Starting Index</param>
+        /// <param name="count">Number of the indexes to check.</param>
+        /// <returns></returns>
         private bool CheckForIndexes(int baseIndex, int count)
         {
             for (int i = baseIndex; i < baseIndex + count; i++)
@@ -754,6 +753,11 @@ namespace UoFiddler.Controls.UserControls
             return true;
         }
 
+        /// <summary>
+        /// Adds a single Gump.
+        /// </summary>
+        /// <param name="fileName">Filename of the gump to add</param>
+        /// <param name="index">Index where the gump shall be added.</param>
         private void AddSingleGump(string fileName, int index)
         {
             Bitmap bmp = new Bitmap(fileName);

--- a/UoFiddler.Controls/UserControls/GumpControl.cs
+++ b/UoFiddler.Controls/UserControls/GumpControl.cs
@@ -697,5 +697,104 @@ namespace UoFiddler.Controls.UserControls
             e.SuppressKeyPress = true;
             e.Handled = true;
         }
+
+        private void InsertStartingFromTb_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode != Keys.Enter)
+            {
+                return;
+            }
+
+            if (!Utils.ConvertStringToInt(InsertStartingFromTb.Text, out int index, 0, Gumps.GetCount()))
+            {
+                return;
+            }
+
+
+            contextMenuStrip1.Close();
+            using (OpenFileDialog dialog = new OpenFileDialog())
+            {
+                dialog.Multiselect = true;
+                dialog.Title = $"Choose image file to insert at 0x{index:X}";
+                dialog.CheckFileExists = true;
+                dialog.Filter = "Image files (*.tif;*.tiff;*.bmp)|*.tif;*.tiff;*.bmp";
+                if (dialog.ShowDialog() != DialogResult.OK)
+                {
+                    return;
+                }
+
+
+
+                if (CheckForIndexes(index, dialog.FileNames.Length))
+                {
+                    for(int i = 0; i < dialog.FileNames.Length; i++)
+                    {
+                        var currentIdx = index + i;
+                        AddSingleGump(dialog.FileNames[i], currentIdx);
+                    }
+                }
+
+                
+
+                
+            }
+
+            Options.ChangedUltimaClass["Gumps"] = true;
+        }
+
+        private bool CheckForIndexes(int baseIndex, int count)
+        {
+            for (int i = baseIndex; i < baseIndex + count; i++)
+            {
+                if (Gumps.IsValidIndex(i))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private void AddSingleGump(string fileName, int index)
+        {
+            Bitmap bmp = new Bitmap(fileName);
+            if (fileName.Contains(".bmp"))
+            {
+                bmp = Utils.ConvertBmp(bmp);
+            }
+            Gumps.ReplaceGump(index, bmp);
+            ControlEvents.FireGumpChangeEvent(this, index);
+            bool done = false;
+            for (int i = 0; i < listBox.Items.Count; ++i)
+            {
+                int j = int.Parse(listBox.Items[i].ToString());
+                if (j > index)
+                {
+                    listBox.Items.Insert(i, index);
+                    listBox.SelectedIndex = i;
+                    done = true;
+                    break;
+                }
+
+                if (!_showFreeSlots)
+                {
+                    continue;
+                }
+
+                if (j != i)
+                {
+                    continue;
+                }
+
+                listBox.SelectedIndex = i;
+                done = true;
+                break;
+            }
+
+            if (!done)
+            {
+                listBox.Items.Add(index);
+                listBox.SelectedIndex = listBox.Items.Count - 1;
+            }
+        }
     }
 }

--- a/UoFiddler.Controls/UserControls/GumpControl.cs
+++ b/UoFiddler.Controls/UserControls/GumpControl.cs
@@ -745,7 +745,7 @@ namespace UoFiddler.Controls.UserControls
         {
             for (int i = baseIndex; i < baseIndex + count; i++)
             {
-                if (Gumps.IsValidIndex(i))
+                if (i >= Gumps.GetCount() || Gumps.IsValidIndex(i))
                 {
                     return false;
                 }

--- a/UoFiddler.Controls/UserControls/LandTilesAlternativeControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/LandTilesAlternativeControl.Designer.cs
@@ -68,12 +68,14 @@ namespace UoFiddler.Controls.UserControls
             this.ExportAllAsTiff = new System.Windows.Forms.ToolStripMenuItem();
             this.asJpgToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.asPngToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.SearchButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
+            this.SearchButton = new System.Windows.Forms.ToolStripButton();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.SaveButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this.LandTilesTileView = new UoFiddler.Controls.UserControls.TileView.TileViewControl();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.insertStartingFromToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.InsertStartingFromTb = new System.Windows.Forms.ToolStripTextBox();
             this.LandTilesContextMenuStrip.SuspendLayout();
             this.LandTilesToolStrip.SuspendLayout();
             this.SuspendLayout();
@@ -89,9 +91,10 @@ namespace UoFiddler.Controls.UserControls
             this.findNextFreeSlotToolStripMenuItem,
             this.removeToolStripMenuItem,
             this.replaceToolStripMenuItem,
-            this.insertAtToolStripMenuItem});
+            this.insertAtToolStripMenuItem,
+            this.insertStartingFromToolStripMenuItem});
             this.LandTilesContextMenuStrip.Name = "contextMenuStrip1";
-            this.LandTilesContextMenuStrip.Size = new System.Drawing.Size(201, 170);
+            this.LandTilesContextMenuStrip.Size = new System.Drawing.Size(201, 214);
             // 
             // exportImageToolStripMenuItem
             // 
@@ -255,7 +258,7 @@ namespace UoFiddler.Controls.UserControls
             this.asJpgToolStripMenuItem,
             this.asPngToolStripMenuItem1});
             this.exportAllToolStripMenuItem.Name = "exportAllToolStripMenuItem";
-            this.exportAllToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.exportAllToolStripMenuItem.Size = new System.Drawing.Size(131, 22);
             this.exportAllToolStripMenuItem.Text = "Export All..";
             // 
             // ExportAllAsBmp
@@ -286,6 +289,12 @@ namespace UoFiddler.Controls.UserControls
             this.asPngToolStripMenuItem1.Text = "As Png";
             this.asPngToolStripMenuItem1.Click += new System.EventHandler(this.OnClick_SaveAllPng);
             // 
+            // toolStripSeparator5
+            // 
+            this.toolStripSeparator5.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.toolStripSeparator5.Name = "toolStripSeparator5";
+            this.toolStripSeparator5.Size = new System.Drawing.Size(6, 25);
+            // 
             // SearchButton
             // 
             this.SearchButton.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
@@ -296,11 +305,11 @@ namespace UoFiddler.Controls.UserControls
             this.SearchButton.Text = "Search";
             this.SearchButton.Click += new System.EventHandler(this.OnClickSearch);
             // 
-            // toolStripSeparator5
+            // toolStripSeparator1
             // 
-            this.toolStripSeparator5.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.toolStripSeparator5.Name = "toolStripSeparator5";
-            this.toolStripSeparator5.Size = new System.Drawing.Size(6, 25);
+            this.toolStripSeparator1.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
             // 
             // SaveButton
             // 
@@ -342,11 +351,20 @@ namespace UoFiddler.Controls.UserControls
             this.LandTilesTileView.ItemSelectionChanged += new System.EventHandler<System.Windows.Forms.ListViewItemSelectionChangedEventArgs>(this.LandTilesTileView_ItemSelectionChanged);
             this.LandTilesTileView.DrawItem += new System.EventHandler<UoFiddler.Controls.UserControls.TileView.TileViewControl.DrawTileListItemEventArgs>(this.LandTilesTileView_DrawItem);
             // 
-            // toolStripSeparator1
+            // insertStartingFromToolStripMenuItem
             // 
-            this.toolStripSeparator1.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(6, 25);
+            this.insertStartingFromToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.InsertStartingFromTb});
+            this.insertStartingFromToolStripMenuItem.Name = "insertStartingFromToolStripMenuItem";
+            this.insertStartingFromToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
+            this.insertStartingFromToolStripMenuItem.Text = "Insert Starting From";
+            // 
+            // InsertStartingFromTb
+            // 
+            this.InsertStartingFromTb.Font = new System.Drawing.Font("Segoe UI", 9F);
+            this.InsertStartingFromTb.Name = "InsertStartingFromTb";
+            this.InsertStartingFromTb.Size = new System.Drawing.Size(100, 23);
+            this.InsertStartingFromTb.KeyDown += new System.Windows.Forms.KeyEventHandler(this.InsertStartingFromTb_KeyDown);
             // 
             // LandTilesAlternativeControl
             // 
@@ -400,5 +418,7 @@ namespace UoFiddler.Controls.UserControls
 
         private TileView.TileViewControl LandTilesTileView;
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator1;
+        private System.Windows.Forms.ToolStripMenuItem insertStartingFromToolStripMenuItem;
+        private System.Windows.Forms.ToolStripTextBox InsertStartingFromTb;
     }
 }

--- a/UoFiddler.Controls/UserControls/LandTilesAlternativeControl.cs
+++ b/UoFiddler.Controls/UserControls/LandTilesAlternativeControl.cs
@@ -670,7 +670,7 @@ namespace UoFiddler.Controls.UserControls
         {
             for (int i = baseIndex; i < baseIndex + count; i++)
             {
-                if (Art.IsValidLand(i))
+                if (i >= 0x4000 || Art.IsValidLand(i))
                 {
                     return false;
                 }

--- a/UoFiddler.Controls/UserControls/LandTilesControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/LandTilesControl.Designer.cs
@@ -71,6 +71,8 @@ namespace UoFiddler.Controls.UserControls
             this.SaveButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
             this.listView1 = new System.Windows.Forms.ListView();
+            this.insertStartingFromToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.StartingFromTb = new System.Windows.Forms.ToolStripTextBox();
             this.contextMenuStrip1.SuspendLayout();
             this.toolStripLandTile.SuspendLayout();
             this.SuspendLayout();
@@ -88,9 +90,10 @@ namespace UoFiddler.Controls.UserControls
             this.findNextFreeSlotToolStripMenuItem,
             this.removeToolStripMenuItem,
             this.replaceToolStripMenuItem,
-            this.insertAtToolStripMenuItem});
+            this.insertAtToolStripMenuItem,
+            this.insertStartingFromToolStripMenuItem});
             this.contextMenuStrip1.Name = "contextMenuStrip1";
-            this.contextMenuStrip1.Size = new System.Drawing.Size(201, 192);
+            this.contextMenuStrip1.Size = new System.Drawing.Size(201, 236);
             // 
             // exportImageToolStripMenuItem
             // 
@@ -194,7 +197,6 @@ namespace UoFiddler.Controls.UserControls
             // 
             // InsertText
             // 
-            this.InsertText.Font = new System.Drawing.Font("Segoe UI", 9F);
             this.InsertText.Name = "InsertText";
             this.InsertText.Size = new System.Drawing.Size(100, 23);
             this.InsertText.KeyDown += new System.Windows.Forms.KeyEventHandler(this.OnKeyDown_Insert);
@@ -348,7 +350,21 @@ namespace UoFiddler.Controls.UserControls
             this.listView1.SelectedIndexChanged += new System.EventHandler(this.ListView_SelectedIndexChanged);
             this.listView1.KeyUp += new System.Windows.Forms.KeyEventHandler(this.LandTiles_KeyUp);
             // 
-            // LandTiles
+            // insertStartingFromToolStripMenuItem
+            // 
+            this.insertStartingFromToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.StartingFromTb});
+            this.insertStartingFromToolStripMenuItem.Name = "insertStartingFromToolStripMenuItem";
+            this.insertStartingFromToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
+            this.insertStartingFromToolStripMenuItem.Text = "Insert Starting From";
+            // 
+            // StartingFromTb
+            // 
+            this.StartingFromTb.Name = "StartingFromTb";
+            this.StartingFromTb.Size = new System.Drawing.Size(100, 23);
+            this.StartingFromTb.KeyDown += new System.Windows.Forms.KeyEventHandler(this.toolStripTextBox1_KeyDown);
+            // 
+            // LandTilesControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
@@ -400,5 +416,8 @@ namespace UoFiddler.Controls.UserControls
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator5;
 
         #endregion
+
+        private System.Windows.Forms.ToolStripMenuItem insertStartingFromToolStripMenuItem;
+        private System.Windows.Forms.ToolStripTextBox StartingFromTb;
     }
 }

--- a/UoFiddler.Controls/UserControls/LandTilesControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/LandTilesControl.Designer.cs
@@ -362,7 +362,7 @@ namespace UoFiddler.Controls.UserControls
             // 
             this.StartingFromTb.Name = "StartingFromTb";
             this.StartingFromTb.Size = new System.Drawing.Size(100, 23);
-            this.StartingFromTb.KeyDown += new System.Windows.Forms.KeyEventHandler(this.toolStripTextBox1_KeyDown);
+            this.StartingFromTb.KeyDown += new System.Windows.Forms.KeyEventHandler(this.InsertStartingFromTb_KeyDown);
             // 
             // LandTilesControl
             // 

--- a/UoFiddler.Controls/UserControls/LandTilesControl.cs
+++ b/UoFiddler.Controls/UserControls/LandTilesControl.cs
@@ -1,9 +1,9 @@
 /***************************************************************************
  *
  * $Author: Turley
- * 
+ *
  * "THE BEER-WARE LICENSE"
- * As long as you retain this notice you can do whatever you want with 
+ * As long as you retain this notice you can do whatever you want with
  * this stuff. If we meet some day, and you think this stuff is worth it,
  * you can buy me a beer in return.
  *
@@ -870,7 +870,7 @@ namespace UoFiddler.Controls.UserControls
             e.Handled = true;
         }
 
-        private void toolStripTextBox1_KeyDown(object sender, KeyEventArgs e)
+        private void InsertStartingFromTb_KeyDown(object sender, KeyEventArgs e)
         {
             if (e.KeyCode != Keys.Enter || !Utils.ConvertStringToInt(StartingFromTb.Text, out int index, 0, 0x3FFF))
             {
@@ -894,17 +894,14 @@ namespace UoFiddler.Controls.UserControls
                     return;
                 }
 
-                
                 if (CheckForIndexes(index, dialog.FileNames.Length)) //Ho tutti gli indici necessari disponibili in linea
                 {
-                    for(int i = 0; i < dialog.FileNames.Length; i++)
+                    for (int i = 0; i < dialog.FileNames.Length; i++)
                     {
                         var currentIdx = index + i;
                         AddSingleLandTile(dialog.FileNames[i], currentIdx);
                     }
                 }
-
-
 
                 listView1.View = View.Details; // that works fascinating
                 listView1.View = View.Tile;
@@ -913,27 +910,32 @@ namespace UoFiddler.Controls.UserControls
                 {
                     listView1.SelectedItems[0].Selected = false;
                 }
-
-                //item.Selected = true;
-                //item.Focused = true;
-                //item.EnsureVisible();
             }
         }
 
+        /// <summary>
+        /// Check if all the indexes from baseIndex to baseIndex + count are valid
+        /// </summary>
+        /// <param name="baseIndex">Starting Index</param>
+        /// <param name="count">Number of the indexes to check.</param>
+        /// <returns></returns>
         private bool CheckForIndexes(int baseIndex, int count)
         {
-
-            for(int i = baseIndex; i < baseIndex + count; i++)
+            for (int i = baseIndex; i < baseIndex + count; i++)
             {
                 if (Art.IsValidLand(i))
                 {
                     return false;
                 }
-
             }
             return true;
         }
 
+        /// <summary>
+        /// Adds a single LandTile at the determined index.
+        /// </summary>
+        /// <param name="fileName">The image filename</param>
+        /// <param name="index">The index where the gump should be added</param>
         private void AddSingleLandTile(string fileName, int index)
         {
             Bitmap bmp = new Bitmap(fileName);

--- a/UoFiddler.Controls/UserControls/LandTilesControl.cs
+++ b/UoFiddler.Controls/UserControls/LandTilesControl.cs
@@ -869,5 +869,117 @@ namespace UoFiddler.Controls.UserControls
             e.SuppressKeyPress = true;
             e.Handled = true;
         }
+
+        private void toolStripTextBox1_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode != Keys.Enter || !Utils.ConvertStringToInt(StartingFromTb.Text, out int index, 0, 0x3FFF))
+            {
+                return;
+            }
+
+            if (Art.IsValidLand(index))
+            {
+                return;
+            }
+
+            contextMenuStrip1.Close();
+            using (OpenFileDialog dialog = new OpenFileDialog())
+            {
+                dialog.Multiselect = true;
+                dialog.Title = $"Choose image file to insert at 0x{index:X} +";
+                dialog.CheckFileExists = true;
+                dialog.Filter = "Image files (*.tif;*.tiff;*.bmp)|*.tif;*.tiff;*.bmp";
+                if (dialog.ShowDialog() != DialogResult.OK)
+                {
+                    return;
+                }
+
+                
+                if (CheckForIndexes(index, dialog.FileNames.Length)) //Ho tutti gli indici necessari disponibili in linea
+                {
+                    for(int i = 0; i < dialog.FileNames.Length; i++)
+                    {
+                        var currentIdx = index + i;
+                        AddSingleLandTile(dialog.FileNames[i], currentIdx);
+                    }
+                }
+
+
+
+                listView1.View = View.Details; // that works fascinating
+                listView1.View = View.Tile;
+
+                if (listView1.SelectedItems.Count == 1)
+                {
+                    listView1.SelectedItems[0].Selected = false;
+                }
+
+                //item.Selected = true;
+                //item.Focused = true;
+                //item.EnsureVisible();
+            }
+        }
+
+        private bool CheckForIndexes(int baseIndex, int count)
+        {
+
+            for(int i = baseIndex; i < baseIndex + count; i++)
+            {
+                if (Art.IsValidLand(i))
+                {
+                    return false;
+                }
+
+            }
+            return true;
+        }
+
+        private void AddSingleLandTile(string fileName, int index)
+        {
+            Bitmap bmp = new Bitmap(fileName);
+            if (bmp.Height != 44 || bmp.Width != 44)
+            {
+                MessageBox.Show("Height or Width Invalid", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error, MessageBoxDefaultButton.Button1);
+                return;
+            }
+            if (fileName.Contains(".bmp"))
+            {
+                bmp = Utils.ConvertBmp(bmp);
+            }
+
+            Art.ReplaceLand(index, bmp);
+            ControlEvents.FireLandTileChangeEvent(this, index);
+            Options.ChangedUltimaClass["Art"] = true;
+            ListViewItem item = new ListViewItem(index.ToString(), 0)
+            {
+                Tag = index
+            };
+
+            if (_showFreeSlots)
+            {
+                listView1.Items[index] = item;
+                listView1.Invalidate();
+            }
+            else
+            {
+                bool done = false;
+                foreach (ListViewItem i in listView1.Items)
+                {
+                    if ((int)i.Tag <= index)
+                    {
+                        continue;
+                    }
+
+                    listView1.Items.Insert(i.Index, item);
+                    done = true;
+                    break;
+                }
+
+                if (!done)
+                {
+                    listView1.Items.Add(item);
+                }
+            }
+        }
     }
 }

--- a/UoFiddler.Controls/UserControls/LandTilesControl.cs
+++ b/UoFiddler.Controls/UserControls/LandTilesControl.cs
@@ -877,11 +877,6 @@ namespace UoFiddler.Controls.UserControls
                 return;
             }
 
-            if (Art.IsValidLand(index))
-            {
-                return;
-            }
-
             contextMenuStrip1.Close();
             using (OpenFileDialog dialog = new OpenFileDialog())
             {
@@ -923,7 +918,7 @@ namespace UoFiddler.Controls.UserControls
         {
             for (int i = baseIndex; i < baseIndex + count; i++)
             {
-                if (Art.IsValidLand(i))
+                if (i >= 0x4000 || Art.IsValidLand(i))
                 {
                     return false;
                 }

--- a/UoFiddler.Controls/UserControls/TextureAlternativeControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/TextureAlternativeControl.Designer.cs
@@ -66,6 +66,8 @@ namespace UoFiddler.Controls.UserControls
             this.SaveButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.TextureTileView = new UoFiddler.Controls.UserControls.TileView.TileViewControl();
+            this.insertStartingFromToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.InsertStartingFromTb = new System.Windows.Forms.ToolStripTextBox();
             this.contextMenuStrip1.SuspendLayout();
             this.toolStrip1.SuspendLayout();
             this.SuspendLayout();
@@ -78,9 +80,10 @@ namespace UoFiddler.Controls.UserControls
             this.findNextFreeSlotToolStripMenuItem,
             this.removeToolStripMenuItem,
             this.replaceToolStripMenuItem,
-            this.insertAtToolStripMenuItem});
+            this.insertAtToolStripMenuItem,
+            this.insertStartingFromToolStripMenuItem});
             this.contextMenuStrip1.Name = "contextMenuStrip1";
-            this.contextMenuStrip1.Size = new System.Drawing.Size(174, 120);
+            this.contextMenuStrip1.Size = new System.Drawing.Size(185, 164);
             // 
             // exportImageToolStripMenuItem
             // 
@@ -90,7 +93,7 @@ namespace UoFiddler.Controls.UserControls
             this.asJpgToolStripMenuItem,
             this.asPngToolStripMenuItem});
             this.exportImageToolStripMenuItem.Name = "exportImageToolStripMenuItem";
-            this.exportImageToolStripMenuItem.Size = new System.Drawing.Size(173, 22);
+            this.exportImageToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
             this.exportImageToolStripMenuItem.Text = "Export Image..";
             // 
             // asBmpToolStripMenuItem
@@ -124,26 +127,26 @@ namespace UoFiddler.Controls.UserControls
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(170, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(181, 6);
             // 
             // findNextFreeSlotToolStripMenuItem
             // 
             this.findNextFreeSlotToolStripMenuItem.Name = "findNextFreeSlotToolStripMenuItem";
-            this.findNextFreeSlotToolStripMenuItem.Size = new System.Drawing.Size(173, 22);
+            this.findNextFreeSlotToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
             this.findNextFreeSlotToolStripMenuItem.Text = "Find Next Free Slot";
             this.findNextFreeSlotToolStripMenuItem.Click += new System.EventHandler(this.OnClickFindNext);
             // 
             // removeToolStripMenuItem
             // 
             this.removeToolStripMenuItem.Name = "removeToolStripMenuItem";
-            this.removeToolStripMenuItem.Size = new System.Drawing.Size(173, 22);
+            this.removeToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
             this.removeToolStripMenuItem.Text = "Remove";
             this.removeToolStripMenuItem.Click += new System.EventHandler(this.OnClickRemove);
             // 
             // replaceToolStripMenuItem
             // 
             this.replaceToolStripMenuItem.Name = "replaceToolStripMenuItem";
-            this.replaceToolStripMenuItem.Size = new System.Drawing.Size(173, 22);
+            this.replaceToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
             this.replaceToolStripMenuItem.Text = "Replace";
             this.replaceToolStripMenuItem.Click += new System.EventHandler(this.OnClickReplace);
             // 
@@ -152,7 +155,7 @@ namespace UoFiddler.Controls.UserControls
             this.insertAtToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.InsertText});
             this.insertAtToolStripMenuItem.Name = "insertAtToolStripMenuItem";
-            this.insertAtToolStripMenuItem.Size = new System.Drawing.Size(173, 22);
+            this.insertAtToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
             this.insertAtToolStripMenuItem.Text = "Insert At..";
             // 
             // InsertText
@@ -208,34 +211,34 @@ namespace UoFiddler.Controls.UserControls
             this.ExportAllAsJpeg,
             this.ExportAllAsPng});
             this.exportAllToolStripMenuItem.Name = "exportAllToolStripMenuItem";
-            this.exportAllToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.exportAllToolStripMenuItem.Size = new System.Drawing.Size(131, 22);
             this.exportAllToolStripMenuItem.Text = "Export All..";
             // 
             // ExportAllAsBmp
             // 
             this.ExportAllAsBmp.Name = "ExportAllAsBmp";
-            this.ExportAllAsBmp.Size = new System.Drawing.Size(180, 22);
+            this.ExportAllAsBmp.Size = new System.Drawing.Size(115, 22);
             this.ExportAllAsBmp.Text = "As Bmp";
             this.ExportAllAsBmp.Click += new System.EventHandler(this.ExportAllAsBmp_Click);
             // 
             // ExportAllAsTiff
             // 
             this.ExportAllAsTiff.Name = "ExportAllAsTiff";
-            this.ExportAllAsTiff.Size = new System.Drawing.Size(180, 22);
+            this.ExportAllAsTiff.Size = new System.Drawing.Size(115, 22);
             this.ExportAllAsTiff.Text = "As Tiff";
             this.ExportAllAsTiff.Click += new System.EventHandler(this.ExportAllAsTiff_Click);
             // 
             // ExportAllAsJpeg
             // 
             this.ExportAllAsJpeg.Name = "ExportAllAsJpeg";
-            this.ExportAllAsJpeg.Size = new System.Drawing.Size(180, 22);
+            this.ExportAllAsJpeg.Size = new System.Drawing.Size(115, 22);
             this.ExportAllAsJpeg.Text = "As Jpg";
             this.ExportAllAsJpeg.Click += new System.EventHandler(this.ExportAllAsJpeg_Click);
             // 
             // ExportAllAsPng
             // 
             this.ExportAllAsPng.Name = "ExportAllAsPng";
-            this.ExportAllAsPng.Size = new System.Drawing.Size(180, 22);
+            this.ExportAllAsPng.Size = new System.Drawing.Size(115, 22);
             this.ExportAllAsPng.Text = "As Png";
             this.ExportAllAsPng.Click += new System.EventHandler(this.ExportAllAsPng_Click);
             // 
@@ -301,6 +304,21 @@ namespace UoFiddler.Controls.UserControls
             this.TextureTileView.ItemSelectionChanged += new System.EventHandler<System.Windows.Forms.ListViewItemSelectionChangedEventArgs>(this.TextureTileView_ItemSelectionChanged);
             this.TextureTileView.DrawItem += new System.EventHandler<UoFiddler.Controls.UserControls.TileView.TileViewControl.DrawTileListItemEventArgs>(this.TextureTileView_DrawItem);
             // 
+            // insertStartingFromToolStripMenuItem
+            // 
+            this.insertStartingFromToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.InsertStartingFromTb});
+            this.insertStartingFromToolStripMenuItem.Name = "insertStartingFromToolStripMenuItem";
+            this.insertStartingFromToolStripMenuItem.Size = new System.Drawing.Size(184, 22);
+            this.insertStartingFromToolStripMenuItem.Text = "Insert Starting From..";
+            // 
+            // InsertStartingFromTb
+            // 
+            this.InsertStartingFromTb.Font = new System.Drawing.Font("Segoe UI", 9F);
+            this.InsertStartingFromTb.Name = "InsertStartingFromTb";
+            this.InsertStartingFromTb.Size = new System.Drawing.Size(100, 23);
+            this.InsertStartingFromTb.KeyDown += new System.Windows.Forms.KeyEventHandler(this.InsertStartingFrom_OnInsert);
+            // 
             // TextureAlternativeControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -348,5 +366,7 @@ namespace UoFiddler.Controls.UserControls
         private System.Windows.Forms.ToolStripMenuItem ExportAllAsTiff;
         private System.Windows.Forms.ToolStripMenuItem ExportAllAsJpeg;
         private System.Windows.Forms.ToolStripMenuItem ExportAllAsPng;
+        private System.Windows.Forms.ToolStripMenuItem insertStartingFromToolStripMenuItem;
+        private System.Windows.Forms.ToolStripTextBox InsertStartingFromTb;
     }
 }

--- a/UoFiddler.Controls/UserControls/TextureAlternativeControl.cs
+++ b/UoFiddler.Controls/UserControls/TextureAlternativeControl.cs
@@ -264,7 +264,7 @@ namespace UoFiddler.Controls.UserControls
 
         private void OnTextChangedInsert(object sender, EventArgs e)
         {
-            if (Utils.ConvertStringToInt(InsertText.Text, out int index, 0, 0xFFF))
+            if (Utils.ConvertStringToInt(InsertText.Text, out int index, 0, 0x3FFF))
             {
                 InsertText.ForeColor = Textures.TestTexture(index) ? Color.Red : Color.Black;
             }
@@ -281,7 +281,7 @@ namespace UoFiddler.Controls.UserControls
                 return;
             }
 
-            if (!Utils.ConvertStringToInt(InsertText.Text, out int index, 0, 0xFFF))
+            if (!Utils.ConvertStringToInt(InsertText.Text, out int index, 0, 0x3FFF))
             {
                 return;
             }

--- a/UoFiddler.Controls/UserControls/TextureAlternativeControl.cs
+++ b/UoFiddler.Controls/UserControls/TextureAlternativeControl.cs
@@ -1,9 +1,9 @@
 /***************************************************************************
  *
  * $Author: Turley
- * 
+ *
  * "THE BEER-WARE LICENSE"
- * As long as you retain this notice you can do whatever you want with 
+ * As long as you retain this notice you can do whatever you want with
  * this stuff. If we meet some day, and you think this stuff is worth it,
  * you can buy me a beer in return.
  *
@@ -39,6 +39,7 @@ namespace UoFiddler.Controls.UserControls
         private bool _loaded;
 
         private int _selectedTextureId = -1;
+
         public int SelectedTextureId
         {
             get => _selectedTextureId;
@@ -501,6 +502,110 @@ namespace UoFiddler.Controls.UserControls
 
                 MessageBox.Show($"All textures saved to {dialog.SelectedPath}", "Saved", MessageBoxButtons.OK,
                     MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);
+            }
+        }
+
+        private void InsertStartingFrom_OnInsert(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode != Keys.Enter)
+            {
+                return;
+            }
+            //Why were we using 0xFFF for the Textures and 0x3FFF for the Landtiles?
+            if (!Utils.ConvertStringToInt(InsertStartingFromTb.Text, out int index, 0, 0x3FFF))
+            {
+                return;
+            }
+
+            contextMenuStrip1.Close();
+
+            using (OpenFileDialog dialog = new OpenFileDialog())
+            {
+                dialog.Multiselect = true;
+                dialog.Title = $"Choose images file to insert at 0x{index:X}";
+                dialog.CheckFileExists = true;
+                dialog.Filter = "Image files (*.tif;*.tiff;*.bmp)|*.tif;*.tiff;*.bmp";
+                if (dialog.ShowDialog() != DialogResult.OK)
+                {
+                    return;
+                }
+
+                var fileCount = dialog.FileNames.Length;
+
+                if (CheckForIndexes(index, fileCount))
+                {
+                    for (int i = 0; i < fileCount; i++)
+                    {
+                        AddSingleTexture(dialog.FileNames[i], index + i);
+                    }
+                }
+
+                TextureTileView.VirtualListSize = _textureList.Count;
+                TextureTileView.Invalidate();
+                SelectedTextureId = index;
+
+                Options.ChangedUltimaClass["Texture"] = true;
+            }
+        }
+
+        /// <summary>
+        /// Check if all the indexes from baseIndex to baseIndex + count are valid
+        /// </summary>
+        /// <param name="baseIndex">Starting Index</param>
+        /// <param name="count">Number of the indexes to check.</param>
+        /// <returns></returns>
+        private bool CheckForIndexes(int baseIndex, int count)
+        {
+            for (int i = baseIndex; i < baseIndex + count; i++)
+            {
+                if (Textures.TestTexture(i))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Adds a single Texture.
+        /// </summary>
+        /// <param name="fileName">Filename of the image to add.</param>
+        /// <param name="index">Index where the texture will be added.</param>
+        private void AddSingleTexture(string fileName, int index)
+        {
+            Bitmap bmp = new Bitmap(fileName);
+            if ((bmp.Width == 64 && bmp.Height == 64) || (bmp.Width == 128 && bmp.Height == 128))
+            {
+                if (fileName.Contains(".bmp"))
+                {
+                    bmp = Utils.ConvertBmp(bmp);
+                }
+
+                Textures.Replace(index, bmp);
+                ControlEvents.FireTextureChangeEvent(this, index);
+                bool done = false;
+                for (int i = 0; i < _textureList.Count; ++i)
+                {
+                    if (index >= _textureList[i])
+                    {
+                        continue;
+                    }
+
+                    _textureList.Insert(i, index);
+
+                    done = true;
+                    break;
+                }
+
+                if (!done)
+                {
+                    _textureList.Add(index);
+                }
+            }
+            else
+            {
+                MessageBox.Show("Height or Width Invalid", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error,
+                    MessageBoxDefaultButton.Button1);
             }
         }
     }

--- a/UoFiddler.Controls/UserControls/TextureAlternativeControl.cs
+++ b/UoFiddler.Controls/UserControls/TextureAlternativeControl.cs
@@ -558,7 +558,7 @@ namespace UoFiddler.Controls.UserControls
         {
             for (int i = baseIndex; i < baseIndex + count; i++)
             {
-                if (Textures.TestTexture(i))
+                if (i >= 0x4000 || Textures.TestTexture(i))
                 {
                     return false;
                 }

--- a/UoFiddler.Controls/UserControls/TextureControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/TextureControl.Designer.cs
@@ -66,6 +66,8 @@ namespace UoFiddler.Controls.UserControls
             this.toolStripSeparator4 = new System.Windows.Forms.ToolStripSeparator();
             this.SaveButton = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+            this.insertStartingFromToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.StartingPosTb = new System.Windows.Forms.ToolStripTextBox();
             this.contextMenuStrip1.SuspendLayout();
             this.toolStrip1.SuspendLayout();
             this.SuspendLayout();
@@ -98,9 +100,10 @@ namespace UoFiddler.Controls.UserControls
             this.findNextFreeSlotToolStripMenuItem,
             this.removeToolStripMenuItem,
             this.replaceToolStripMenuItem,
-            this.insertAtToolStripMenuItem});
+            this.insertAtToolStripMenuItem,
+            this.insertStartingFromToolStripMenuItem});
             this.contextMenuStrip1.Name = "contextMenuStrip1";
-            this.contextMenuStrip1.Size = new System.Drawing.Size(174, 120);
+            this.contextMenuStrip1.Size = new System.Drawing.Size(181, 164);
             // 
             // exportImageToolStripMenuItem
             // 
@@ -110,7 +113,7 @@ namespace UoFiddler.Controls.UserControls
             this.asJpgToolStripMenuItem,
             this.asPngToolStripMenuItem});
             this.exportImageToolStripMenuItem.Name = "exportImageToolStripMenuItem";
-            this.exportImageToolStripMenuItem.Size = new System.Drawing.Size(173, 22);
+            this.exportImageToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.exportImageToolStripMenuItem.Text = "Export Image";
             // 
             // asBmpToolStripMenuItem
@@ -144,26 +147,26 @@ namespace UoFiddler.Controls.UserControls
             // toolStripSeparator2
             // 
             this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(170, 6);
+            this.toolStripSeparator2.Size = new System.Drawing.Size(177, 6);
             // 
             // findNextFreeSlotToolStripMenuItem
             // 
             this.findNextFreeSlotToolStripMenuItem.Name = "findNextFreeSlotToolStripMenuItem";
-            this.findNextFreeSlotToolStripMenuItem.Size = new System.Drawing.Size(173, 22);
+            this.findNextFreeSlotToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.findNextFreeSlotToolStripMenuItem.Text = "Find Next Free Slot";
             this.findNextFreeSlotToolStripMenuItem.Click += new System.EventHandler(this.OnClickFindNext);
             // 
             // removeToolStripMenuItem
             // 
             this.removeToolStripMenuItem.Name = "removeToolStripMenuItem";
-            this.removeToolStripMenuItem.Size = new System.Drawing.Size(173, 22);
+            this.removeToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.removeToolStripMenuItem.Text = "Remove";
             this.removeToolStripMenuItem.Click += new System.EventHandler(this.OnClickRemove);
             // 
             // replaceToolStripMenuItem
             // 
             this.replaceToolStripMenuItem.Name = "replaceToolStripMenuItem";
-            this.replaceToolStripMenuItem.Size = new System.Drawing.Size(173, 22);
+            this.replaceToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.replaceToolStripMenuItem.Text = "Replace";
             this.replaceToolStripMenuItem.Click += new System.EventHandler(this.OnClickReplace);
             // 
@@ -172,7 +175,7 @@ namespace UoFiddler.Controls.UserControls
             this.insertAtToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.InsertText});
             this.insertAtToolStripMenuItem.Name = "insertAtToolStripMenuItem";
-            this.insertAtToolStripMenuItem.Size = new System.Drawing.Size(173, 22);
+            this.insertAtToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
             this.insertAtToolStripMenuItem.Text = "Insert At..";
             // 
             // InsertText
@@ -228,34 +231,34 @@ namespace UoFiddler.Controls.UserControls
             this.ExportAllAsJpeg,
             this.ExportAllAsPng});
             this.exportAllToolStripMenuItem.Name = "exportAllToolStripMenuItem";
-            this.exportAllToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.exportAllToolStripMenuItem.Size = new System.Drawing.Size(131, 22);
             this.exportAllToolStripMenuItem.Text = "Export All..";
             // 
             // ExportAllAsBmp
             // 
             this.ExportAllAsBmp.Name = "ExportAllAsBmp";
-            this.ExportAllAsBmp.Size = new System.Drawing.Size(180, 22);
+            this.ExportAllAsBmp.Size = new System.Drawing.Size(115, 22);
             this.ExportAllAsBmp.Text = "As Bmp";
             this.ExportAllAsBmp.Click += new System.EventHandler(this.ExportAllAsBmp_Click);
             // 
             // ExportAllAsTiff
             // 
             this.ExportAllAsTiff.Name = "ExportAllAsTiff";
-            this.ExportAllAsTiff.Size = new System.Drawing.Size(180, 22);
+            this.ExportAllAsTiff.Size = new System.Drawing.Size(115, 22);
             this.ExportAllAsTiff.Text = "As Tiff";
             this.ExportAllAsTiff.Click += new System.EventHandler(this.ExportAllAsTiff_Click);
             // 
             // ExportAllAsJpeg
             // 
             this.ExportAllAsJpeg.Name = "ExportAllAsJpeg";
-            this.ExportAllAsJpeg.Size = new System.Drawing.Size(180, 22);
+            this.ExportAllAsJpeg.Size = new System.Drawing.Size(115, 22);
             this.ExportAllAsJpeg.Text = "As Jpg";
             this.ExportAllAsJpeg.Click += new System.EventHandler(this.ExportAllAsJpeg_Click);
             // 
             // ExportAllAsPng
             // 
             this.ExportAllAsPng.Name = "ExportAllAsPng";
-            this.ExportAllAsPng.Size = new System.Drawing.Size(180, 22);
+            this.ExportAllAsPng.Size = new System.Drawing.Size(115, 22);
             this.ExportAllAsPng.Text = "As Png";
             this.ExportAllAsPng.Click += new System.EventHandler(this.ExportAllAsPng_Click);
             // 
@@ -296,6 +299,21 @@ namespace UoFiddler.Controls.UserControls
             this.toolStripSeparator3.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
             this.toolStripSeparator3.Name = "toolStripSeparator3";
             this.toolStripSeparator3.Size = new System.Drawing.Size(6, 25);
+            // 
+            // insertStartingFromToolStripMenuItem
+            // 
+            this.insertStartingFromToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.StartingPosTb});
+            this.insertStartingFromToolStripMenuItem.Name = "insertStartingFromToolStripMenuItem";
+            this.insertStartingFromToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+            this.insertStartingFromToolStripMenuItem.Text = "Insert Starting From";
+            // 
+            // StartingPosTb
+            // 
+            this.StartingPosTb.Font = new System.Drawing.Font("Segoe UI", 9F);
+            this.StartingPosTb.Name = "StartingPosTb";
+            this.StartingPosTb.Size = new System.Drawing.Size(100, 23);
+            this.StartingPosTb.KeyDown += new System.Windows.Forms.KeyEventHandler(this.StartingPosTb_KeyDown);
             // 
             // TextureControl
             // 
@@ -345,5 +363,7 @@ namespace UoFiddler.Controls.UserControls
         private System.Windows.Forms.ToolStripMenuItem ExportAllAsTiff;
         private System.Windows.Forms.ToolStripMenuItem ExportAllAsJpeg;
         private System.Windows.Forms.ToolStripMenuItem ExportAllAsPng;
+        private System.Windows.Forms.ToolStripMenuItem insertStartingFromToolStripMenuItem;
+        private System.Windows.Forms.ToolStripTextBox StartingPosTb;
     }
 }

--- a/UoFiddler.Controls/UserControls/TextureControl.cs
+++ b/UoFiddler.Controls/UserControls/TextureControl.cs
@@ -559,11 +559,6 @@ namespace UoFiddler.Controls.UserControls
                 return;
             }
 
-            //if (Textures.TestTexture(index))
-            //{
-            //    return;
-            //}
-
             contextMenuStrip1.Close();
             using (OpenFileDialog dialog = new OpenFileDialog())
             {
@@ -586,7 +581,6 @@ namespace UoFiddler.Controls.UserControls
                     }
                 }
 
-
                 listView1.View = View.Details; // that works fascinating
                 listView1.View = View.Tile;
 
@@ -595,10 +589,15 @@ namespace UoFiddler.Controls.UserControls
                     listView1.SelectedItems[0].Selected = false;
                 }
                 Options.ChangedUltimaClass["Texture"] = true;
-                
             }
         }
 
+        /// <summary>
+        /// Check if all the indexes from baseIndex to baseIndex + count are valid
+        /// </summary>
+        /// <param name="baseIndex">Starting Index</param>
+        /// <param name="count">Number of the indexes to check.</param>
+        /// <returns></returns>
         private bool CheckForIndexes(int baseIndex, int count)
         {
             for (int i = baseIndex; i < baseIndex + count; i++)
@@ -611,6 +610,11 @@ namespace UoFiddler.Controls.UserControls
             return true;
         }
 
+        /// <summary>
+        /// Adds a single Texture.
+        /// </summary>
+        /// <param name="fileName">Filename of the image to add.</param>
+        /// <param name="index">Index where the texture will be added.</param>
         private void AddSingleTexture(string fileName, int index)
         {
             Bitmap bmp = new Bitmap(fileName);

--- a/UoFiddler.Controls/UserControls/TextureControl.cs
+++ b/UoFiddler.Controls/UserControls/TextureControl.cs
@@ -602,7 +602,7 @@ namespace UoFiddler.Controls.UserControls
         {
             for (int i = baseIndex; i < baseIndex + count; i++)
             {
-                if (Textures.TestTexture(i))
+                if (i >= Textures.GetIdxLength() || Textures.TestTexture(i))
                 {
                     return false;
                 }

--- a/UoFiddler.Controls/UserControls/TextureControl.cs
+++ b/UoFiddler.Controls/UserControls/TextureControl.cs
@@ -1,9 +1,9 @@
 /***************************************************************************
  *
  * $Author: Turley
- * 
+ *
  * "THE BEER-WARE LICENSE"
- * As long as you retain this notice you can do whatever you want with 
+ * As long as you retain this notice you can do whatever you want with
  * this stuff. If we meet some day, and you think this stuff is worth it,
  * you can buy me a beer in return.
  *
@@ -544,6 +544,106 @@ namespace UoFiddler.Controls.UserControls
 
                 MessageBox.Show($"All textures saved to {dialog.SelectedPath}", "Saved", MessageBoxButtons.OK,
                     MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);
+            }
+        }
+
+        private void StartingPosTb_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyCode != Keys.Enter)
+            {
+                return;
+            }
+
+            if (!Utils.ConvertStringToInt(StartingPosTb.Text, out int index, 0, Textures.GetIdxLength()))
+            {
+                return;
+            }
+
+            //if (Textures.TestTexture(index))
+            //{
+            //    return;
+            //}
+
+            contextMenuStrip1.Close();
+            using (OpenFileDialog dialog = new OpenFileDialog())
+            {
+                dialog.Multiselect = true;
+                dialog.Title = $"Choose image file to insert at 0x{index:X}";
+                dialog.CheckFileExists = true;
+                dialog.Filter = "Image files (*.tif;*.tiff;*.bmp)|*.tif;*.tiff;*.bmp";
+                if (dialog.ShowDialog() != DialogResult.OK)
+                {
+                    return;
+                }
+
+                var fileCount = dialog.FileNames.Length;
+
+                if (CheckForIndexes(index, fileCount))
+                {
+                    for (int i = 0; i < fileCount; i++)
+                    {
+                        AddSingleTexture(dialog.FileNames[i], index + i);
+                    }
+                }
+
+
+                listView1.View = View.Details; // that works fascinating
+                listView1.View = View.Tile;
+
+                if (listView1.SelectedItems.Count == 1)
+                {
+                    listView1.SelectedItems[0].Selected = false;
+                }
+                Options.ChangedUltimaClass["Texture"] = true;
+                
+            }
+        }
+
+        private bool CheckForIndexes(int baseIndex, int count)
+        {
+            for (int i = baseIndex; i < baseIndex + count; i++)
+            {
+                if (Textures.TestTexture(i))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private void AddSingleTexture(string fileName, int index)
+        {
+            Bitmap bmp = new Bitmap(fileName);
+            if ((bmp.Width == 64 && bmp.Height == 64) || (bmp.Width == 128 && bmp.Height == 128))
+            {
+                Textures.Replace(index, bmp);
+                ControlEvents.FireTextureChangeEvent(this, index);
+                ListViewItem item = new ListViewItem(index.ToString(), 0)
+                {
+                    Tag = index
+                };
+                bool done = false;
+                foreach (ListViewItem i in listView1.Items)
+                {
+                    if ((int)i.Tag <= index)
+                    {
+                        continue;
+                    }
+
+                    listView1.Items.Insert(i.Index, item);
+                    done = true;
+                    break;
+                }
+                if (!done)
+                {
+                    listView1.Items.Add(item);
+                }
+            }
+            else
+            {
+                MessageBox.Show("Height or Width Invalid", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error,
+                        MessageBoxDefaultButton.Button1);
+                return;
             }
         }
     }

--- a/UoFiddler.Controls/UserControls/TileDataControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/TileDataControl.Designer.cs
@@ -97,6 +97,7 @@ namespace UoFiddler.Controls.UserControls
             this.memorySaveWarningToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.saveDirectlyOnChangesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.setFilterToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.setTexturesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripButton2 = new System.Windows.Forms.ToolStripButton();
             this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
             this.toolStripButton1 = new System.Windows.Forms.ToolStripButton();
@@ -105,7 +106,6 @@ namespace UoFiddler.Controls.UserControls
             this.toolStripButton4 = new System.Windows.Forms.ToolStripButton();
             this.toolStripButton3 = new System.Windows.Forms.ToolStripButton();
             this.splitter1 = new UoFiddler.Controls.UserControls.CollapsibleSplitter();
-            this.setTexturesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tabcontrol.SuspendLayout();
             this.tabPageItems.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
@@ -157,7 +157,7 @@ namespace UoFiddler.Controls.UserControls
             this.tabPageItems.Location = new System.Drawing.Point(4, 22);
             this.tabPageItems.Name = "tabPageItems";
             this.tabPageItems.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPageItems.Size = new System.Drawing.Size(613, 273);
+            this.tabPageItems.Size = new System.Drawing.Size(613, 268);
             this.tabPageItems.TabIndex = 0;
             this.tabPageItems.Text = "Items";
             this.tabPageItems.UseVisualStyleBackColor = true;
@@ -175,7 +175,7 @@ namespace UoFiddler.Controls.UserControls
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.splitContainer3);
-            this.splitContainer1.Size = new System.Drawing.Size(607, 267);
+            this.splitContainer1.Size = new System.Drawing.Size(607, 262);
             this.splitContainer1.SplitterDistance = 200;
             this.splitContainer1.TabIndex = 0;
             // 
@@ -193,8 +193,8 @@ namespace UoFiddler.Controls.UserControls
             // splitContainer2.Panel2
             // 
             this.splitContainer2.Panel2.Controls.Add(this.pictureBoxItem);
-            this.splitContainer2.Size = new System.Drawing.Size(200, 267);
-            this.splitContainer2.SplitterDistance = 165;
+            this.splitContainer2.Size = new System.Drawing.Size(200, 262);
+            this.splitContainer2.SplitterDistance = 161;
             this.splitContainer2.TabIndex = 0;
             // 
             // treeViewItem
@@ -204,7 +204,7 @@ namespace UoFiddler.Controls.UserControls
             this.treeViewItem.HideSelection = false;
             this.treeViewItem.Location = new System.Drawing.Point(0, 0);
             this.treeViewItem.Name = "treeViewItem";
-            this.treeViewItem.Size = new System.Drawing.Size(200, 165);
+            this.treeViewItem.Size = new System.Drawing.Size(200, 161);
             this.treeViewItem.TabIndex = 0;
             this.treeViewItem.BeforeExpand += new System.Windows.Forms.TreeViewCancelEventHandler(this.OnItemDataNodeExpanded);
             this.treeViewItem.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.AfterSelectTreeViewItem);
@@ -260,7 +260,7 @@ namespace UoFiddler.Controls.UserControls
             this.pictureBoxItem.Dock = System.Windows.Forms.DockStyle.Fill;
             this.pictureBoxItem.Location = new System.Drawing.Point(0, 0);
             this.pictureBoxItem.Name = "pictureBoxItem";
-            this.pictureBoxItem.Size = new System.Drawing.Size(200, 98);
+            this.pictureBoxItem.Size = new System.Drawing.Size(200, 97);
             this.pictureBoxItem.TabIndex = 0;
             this.pictureBoxItem.TabStop = false;
             // 
@@ -303,7 +303,7 @@ namespace UoFiddler.Controls.UserControls
             // splitContainer3.Panel2
             // 
             this.splitContainer3.Panel2.Controls.Add(this.checkedListBox1);
-            this.splitContainer3.Size = new System.Drawing.Size(403, 267);
+            this.splitContainer3.Size = new System.Drawing.Size(403, 262);
             this.splitContainer3.SplitterDistance = 157;
             this.splitContainer3.SplitterWidth = 2;
             this.splitContainer3.TabIndex = 25;
@@ -520,7 +520,7 @@ namespace UoFiddler.Controls.UserControls
             this.checkedListBox1.Location = new System.Drawing.Point(0, 0);
             this.checkedListBox1.MultiColumn = true;
             this.checkedListBox1.Name = "checkedListBox1";
-            this.checkedListBox1.Size = new System.Drawing.Size(403, 108);
+            this.checkedListBox1.Size = new System.Drawing.Size(403, 103);
             this.checkedListBox1.TabIndex = 0;
             this.checkedListBox1.ItemCheck += new System.Windows.Forms.ItemCheckEventHandler(this.OnFlagItemCheckItems);
             // 
@@ -662,7 +662,7 @@ namespace UoFiddler.Controls.UserControls
             this.textBoxTexID.Size = new System.Drawing.Size(58, 20);
             this.textBoxTexID.TabIndex = 2;
             this.textBoxTexID.TextChanged += new System.EventHandler(this.OnTextChangedLandTexID);
-            this.textBoxTexID.DoubleClick += new System.EventHandler(this.textBoxTexID_DoubleClick);
+            this.textBoxTexID.DoubleClick += new System.EventHandler(this.TextBoxTexID_DoubleClick);
             // 
             // label24
             // 
@@ -739,6 +739,13 @@ namespace UoFiddler.Controls.UserControls
             this.setFilterToolStripMenuItem.Text = "Set Filter";
             this.setFilterToolStripMenuItem.Click += new System.EventHandler(this.OnClickSetFilter);
             // 
+            // setTexturesToolStripMenuItem
+            // 
+            this.setTexturesToolStripMenuItem.Name = "setTexturesToolStripMenuItem";
+            this.setTexturesToolStripMenuItem.Size = new System.Drawing.Size(204, 22);
+            this.setTexturesToolStripMenuItem.Text = "Set Textures";
+            this.setTexturesToolStripMenuItem.Click += new System.EventHandler(this.SetTextureMenuItem_Click);
+            // 
             // toolStripButton2
             // 
             this.toolStripButton2.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
@@ -808,13 +815,6 @@ namespace UoFiddler.Controls.UserControls
             this.splitter1.TabStop = false;
             this.splitter1.UseAnimations = false;
             this.splitter1.VisualStyle = UoFiddler.Controls.UserControls.VisualStyles.DoubleDots;
-            // 
-            // setTexturesToolStripMenuItem
-            // 
-            this.setTexturesToolStripMenuItem.Name = "setTexturesToolStripMenuItem";
-            this.setTexturesToolStripMenuItem.Size = new System.Drawing.Size(204, 22);
-            this.setTexturesToolStripMenuItem.Text = "Set Textures";
-            this.setTexturesToolStripMenuItem.Click += new System.EventHandler(this.setTexturesToolStripMenuItem_Click);
             // 
             // TileDataControl
             // 

--- a/UoFiddler.Controls/UserControls/TileDataControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/TileDataControl.Designer.cs
@@ -48,6 +48,9 @@ namespace UoFiddler.Controls.UserControls
             this.ItemsContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.selectInItemsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.selectRadarColorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
+            this.selectInGumpsTabMaleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.selectInGumpsTabFemaleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.pictureBoxItem = new System.Windows.Forms.PictureBox();
             this.splitContainer3 = new System.Windows.Forms.SplitContainer();
             this.textBoxName = new System.Windows.Forms.TextBox();
@@ -102,9 +105,7 @@ namespace UoFiddler.Controls.UserControls
             this.toolStripButton4 = new System.Windows.Forms.ToolStripButton();
             this.toolStripButton3 = new System.Windows.Forms.ToolStripButton();
             this.splitter1 = new UoFiddler.Controls.UserControls.CollapsibleSplitter();
-            this.toolStripSeparator3 = new System.Windows.Forms.ToolStripSeparator();
-            this.selectInGumpsTabMaleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.selectInGumpsTabFemaleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.setTexturesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tabcontrol.SuspendLayout();
             this.tabPageItems.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
@@ -156,7 +157,7 @@ namespace UoFiddler.Controls.UserControls
             this.tabPageItems.Location = new System.Drawing.Point(4, 22);
             this.tabPageItems.Name = "tabPageItems";
             this.tabPageItems.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPageItems.Size = new System.Drawing.Size(613, 268);
+            this.tabPageItems.Size = new System.Drawing.Size(613, 273);
             this.tabPageItems.TabIndex = 0;
             this.tabPageItems.Text = "Items";
             this.tabPageItems.UseVisualStyleBackColor = true;
@@ -174,7 +175,7 @@ namespace UoFiddler.Controls.UserControls
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.splitContainer3);
-            this.splitContainer1.Size = new System.Drawing.Size(607, 262);
+            this.splitContainer1.Size = new System.Drawing.Size(607, 267);
             this.splitContainer1.SplitterDistance = 200;
             this.splitContainer1.TabIndex = 0;
             // 
@@ -192,8 +193,8 @@ namespace UoFiddler.Controls.UserControls
             // splitContainer2.Panel2
             // 
             this.splitContainer2.Panel2.Controls.Add(this.pictureBoxItem);
-            this.splitContainer2.Size = new System.Drawing.Size(200, 262);
-            this.splitContainer2.SplitterDistance = 162;
+            this.splitContainer2.Size = new System.Drawing.Size(200, 267);
+            this.splitContainer2.SplitterDistance = 165;
             this.splitContainer2.TabIndex = 0;
             // 
             // treeViewItem
@@ -203,7 +204,7 @@ namespace UoFiddler.Controls.UserControls
             this.treeViewItem.HideSelection = false;
             this.treeViewItem.Location = new System.Drawing.Point(0, 0);
             this.treeViewItem.Name = "treeViewItem";
-            this.treeViewItem.Size = new System.Drawing.Size(200, 162);
+            this.treeViewItem.Size = new System.Drawing.Size(200, 165);
             this.treeViewItem.TabIndex = 0;
             this.treeViewItem.BeforeExpand += new System.Windows.Forms.TreeViewCancelEventHandler(this.OnItemDataNodeExpanded);
             this.treeViewItem.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.AfterSelectTreeViewItem);
@@ -218,7 +219,7 @@ namespace UoFiddler.Controls.UserControls
             this.selectInGumpsTabMaleToolStripMenuItem,
             this.selectInGumpsTabFemaleToolStripMenuItem});
             this.ItemsContextMenuStrip.Name = "contextMenuStrip1";
-            this.ItemsContextMenuStrip.Size = new System.Drawing.Size(201, 120);
+            this.ItemsContextMenuStrip.Size = new System.Drawing.Size(201, 98);
             this.ItemsContextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(this.ItemsContextMenuStrip_Opening);
             // 
             // selectInItemsToolStripMenuItem
@@ -235,12 +236,31 @@ namespace UoFiddler.Controls.UserControls
             this.selectRadarColorToolStripMenuItem.Text = "Select In RadarColor tab";
             this.selectRadarColorToolStripMenuItem.Click += new System.EventHandler(this.OnClickSelectRadarItem);
             // 
+            // toolStripSeparator3
+            // 
+            this.toolStripSeparator3.Name = "toolStripSeparator3";
+            this.toolStripSeparator3.Size = new System.Drawing.Size(197, 6);
+            // 
+            // selectInGumpsTabMaleToolStripMenuItem
+            // 
+            this.selectInGumpsTabMaleToolStripMenuItem.Name = "selectInGumpsTabMaleToolStripMenuItem";
+            this.selectInGumpsTabMaleToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
+            this.selectInGumpsTabMaleToolStripMenuItem.Text = "Select in Gumps (M)";
+            this.selectInGumpsTabMaleToolStripMenuItem.Click += new System.EventHandler(this.SelectInGumpsTabMaleToolStripMenuItem_Click);
+            // 
+            // selectInGumpsTabFemaleToolStripMenuItem
+            // 
+            this.selectInGumpsTabFemaleToolStripMenuItem.Name = "selectInGumpsTabFemaleToolStripMenuItem";
+            this.selectInGumpsTabFemaleToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
+            this.selectInGumpsTabFemaleToolStripMenuItem.Text = "Select in Gumps (F)";
+            this.selectInGumpsTabFemaleToolStripMenuItem.Click += new System.EventHandler(this.SelectInGumpsTabFemaleToolStripMenuItem_Click);
+            // 
             // pictureBoxItem
             // 
             this.pictureBoxItem.Dock = System.Windows.Forms.DockStyle.Fill;
             this.pictureBoxItem.Location = new System.Drawing.Point(0, 0);
             this.pictureBoxItem.Name = "pictureBoxItem";
-            this.pictureBoxItem.Size = new System.Drawing.Size(200, 96);
+            this.pictureBoxItem.Size = new System.Drawing.Size(200, 98);
             this.pictureBoxItem.TabIndex = 0;
             this.pictureBoxItem.TabStop = false;
             // 
@@ -283,7 +303,7 @@ namespace UoFiddler.Controls.UserControls
             // splitContainer3.Panel2
             // 
             this.splitContainer3.Panel2.Controls.Add(this.checkedListBox1);
-            this.splitContainer3.Size = new System.Drawing.Size(403, 262);
+            this.splitContainer3.Size = new System.Drawing.Size(403, 267);
             this.splitContainer3.SplitterDistance = 157;
             this.splitContainer3.SplitterWidth = 2;
             this.splitContainer3.TabIndex = 25;
@@ -500,7 +520,7 @@ namespace UoFiddler.Controls.UserControls
             this.checkedListBox1.Location = new System.Drawing.Point(0, 0);
             this.checkedListBox1.MultiColumn = true;
             this.checkedListBox1.Name = "checkedListBox1";
-            this.checkedListBox1.Size = new System.Drawing.Size(403, 103);
+            this.checkedListBox1.Size = new System.Drawing.Size(403, 108);
             this.checkedListBox1.TabIndex = 0;
             this.checkedListBox1.ItemCheck += new System.Windows.Forms.ItemCheckEventHandler(this.OnFlagItemCheckItems);
             // 
@@ -642,6 +662,7 @@ namespace UoFiddler.Controls.UserControls
             this.textBoxTexID.Size = new System.Drawing.Size(58, 20);
             this.textBoxTexID.TabIndex = 2;
             this.textBoxTexID.TextChanged += new System.EventHandler(this.OnTextChangedLandTexID);
+            this.textBoxTexID.DoubleClick += new System.EventHandler(this.textBoxTexID_DoubleClick);
             // 
             // label24
             // 
@@ -688,7 +709,8 @@ namespace UoFiddler.Controls.UserControls
             this.toolStripDropDownButton1.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.memorySaveWarningToolStripMenuItem,
             this.saveDirectlyOnChangesToolStripMenuItem,
-            this.setFilterToolStripMenuItem});
+            this.setFilterToolStripMenuItem,
+            this.setTexturesToolStripMenuItem});
             this.toolStripDropDownButton1.ImageTransparentColor = System.Drawing.Color.Magenta;
             this.toolStripDropDownButton1.Name = "toolStripDropDownButton1";
             this.toolStripDropDownButton1.Size = new System.Drawing.Size(45, 22);
@@ -787,24 +809,12 @@ namespace UoFiddler.Controls.UserControls
             this.splitter1.UseAnimations = false;
             this.splitter1.VisualStyle = UoFiddler.Controls.UserControls.VisualStyles.DoubleDots;
             // 
-            // toolStripSeparator3
+            // setTexturesToolStripMenuItem
             // 
-            this.toolStripSeparator3.Name = "toolStripSeparator3";
-            this.toolStripSeparator3.Size = new System.Drawing.Size(197, 6);
-            // 
-            // selectInGumpsTabMaleToolStripMenuItem
-            // 
-            this.selectInGumpsTabMaleToolStripMenuItem.Name = "selectInGumpsTabMaleToolStripMenuItem";
-            this.selectInGumpsTabMaleToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.selectInGumpsTabMaleToolStripMenuItem.Text = "Select in Gumps (M)";
-            this.selectInGumpsTabMaleToolStripMenuItem.Click += new System.EventHandler(this.SelectInGumpsTabMaleToolStripMenuItem_Click);
-            // 
-            // selectInGumpsTabFemaleToolStripMenuItem
-            // 
-            this.selectInGumpsTabFemaleToolStripMenuItem.Name = "selectInGumpsTabFemaleToolStripMenuItem";
-            this.selectInGumpsTabFemaleToolStripMenuItem.Size = new System.Drawing.Size(200, 22);
-            this.selectInGumpsTabFemaleToolStripMenuItem.Text = "Select in Gumps (F)";
-            this.selectInGumpsTabFemaleToolStripMenuItem.Click += new System.EventHandler(this.SelectInGumpsTabFemaleToolStripMenuItem_Click);
+            this.setTexturesToolStripMenuItem.Name = "setTexturesToolStripMenuItem";
+            this.setTexturesToolStripMenuItem.Size = new System.Drawing.Size(204, 22);
+            this.setTexturesToolStripMenuItem.Text = "Set Textures";
+            this.setTexturesToolStripMenuItem.Click += new System.EventHandler(this.setTexturesToolStripMenuItem_Click);
             // 
             // TileDataControl
             // 
@@ -927,5 +937,6 @@ namespace UoFiddler.Controls.UserControls
         private System.Windows.Forms.ToolStripSeparator toolStripSeparator3;
         private System.Windows.Forms.ToolStripMenuItem selectInGumpsTabMaleToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem selectInGumpsTabFemaleToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem setTexturesToolStripMenuItem;
     }
 }

--- a/UoFiddler.Controls/UserControls/TileDataControl.cs
+++ b/UoFiddler.Controls/UserControls/TileDataControl.cs
@@ -1,9 +1,9 @@
 /***************************************************************************
  *
  * $Author: Turley
- * 
+ *
  * "THE BEER-WARE LICENSE"
- * As long as you retain this notice you can do whatever you want with 
+ * As long as you retain this notice you can do whatever you want with
  * this stuff. If we meet some day, and you think this stuff is worth it,
  * you can buy me a beer in return.
  *
@@ -1350,18 +1350,23 @@ namespace UoFiddler.Controls.UserControls
                 case 0:
                     changeFlag = TileFlag.Damaging;
                     break;
+
                 case 1:
                     changeFlag = TileFlag.Wet;
                     break;
+
                 case 2:
                     changeFlag = TileFlag.Impassable;
                     break;
+
                 case 3:
                     changeFlag = TileFlag.Wall;
                     break;
+
                 case 4:
                     changeFlag = TileFlag.NoDiagonal;
                     break;
+
                 default:
                     changeFlag = TileFlag.None;
                     break;
@@ -1481,11 +1486,11 @@ namespace UoFiddler.Controls.UserControls
             }
             else
             {
-               var found = LandTilesControl.SearchGraphic(index);
-               if (!found)
-               {
-                   MessageBox.Show("You need to load LandTiles tab first.", "Information");
-               }
+                var found = LandTilesControl.SearchGraphic(index);
+                if (!found)
+                {
+                    MessageBox.Show("You need to load LandTiles tab first.", "Information");
+                }
             }
         }
 
@@ -1635,13 +1640,25 @@ namespace UoFiddler.Controls.UserControls
             }
         }
 
-        private void textBoxTexID_DoubleClick(object sender, EventArgs e)
+        /// <summary>
+        /// DoubleClick event handler on the TextBoxTexID. Sets the TexID to the Tag value of the node 
+        /// i.e. 0x256 (598) lava -> 598.
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void TextBoxTexID_DoubleClick(object sender, EventArgs e)
         {
             int index = (int)treeViewLand.SelectedNode.Tag;
             textBoxTexID.Text = $"{index}";
         }
 
-        private void setTexturesToolStripMenuItem_Click(object sender, EventArgs e)
+        /// <summary>
+        /// Click event handler on the "Set Texture" menu item. Sets all the landtiles TextureID to their index.
+        /// This is written under the assumption that LandTileID == TextureID for every LandTile. 
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void SetTextureMenuItem_Click(object sender, EventArgs e)
         {
             for (int i = 0; i < TileData.LandTable.Length; ++i)
             {

--- a/UoFiddler.Controls/UserControls/TileDataControl.cs
+++ b/UoFiddler.Controls/UserControls/TileDataControl.cs
@@ -1634,5 +1634,22 @@ namespace UoFiddler.Controls.UserControls
                 }
             }
         }
+
+        private void textBoxTexID_DoubleClick(object sender, EventArgs e)
+        {
+            int index = (int)treeViewLand.SelectedNode.Tag;
+            textBoxTexID.Text = $"{index}";
+        }
+
+        private void setTexturesToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            for (int i = 0; i < TileData.LandTable.Length; ++i)
+            {
+                if (Textures.TestTexture(i))
+                {
+                    TileData.LandTable[i].TextureID = (ushort)i;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
New functions: 
- Added some "Insert starting from" buttons in the Land Tiles, Gumps and Textures tabs. It allows user to add multiple files at once starting from chosen index.
- Added "Set Textures" option in Tiledata tab to set every landtile to its textureId.