### PR TITLE
Added UOP to MUL multi converter

### DIFF
--- a/UoFiddler.Plugin.UopPacker/Classes/FileType.cs
+++ b/UoFiddler.Plugin.UopPacker/Classes/FileType.cs
@@ -5,6 +5,7 @@
         ArtLegacyMul,
         GumpartLegacyMul,
         MapLegacyMul,
-        SoundLegacyMul
+        SoundLegacyMul,
+        MultiCollection
     }
 }


### PR DESCRIPTION
Added UOP to MUL converter for multi file.
The implementation is not bidirectional, because of the housing.bin file inside the UOP, but can be used to convert UOP to MUL and open view them with UOFiddler Multi tab