### PR TITLE
Multi and CliLoc improvements 

### DIFF
--- a/Ultima/Files.cs
+++ b/Ultima/Files.cs
@@ -97,6 +97,7 @@ namespace Ultima
             "mobtypes.txt",
             "multi.idx",
             "multi.mul",
+            "multicollection.uop",
             "multimap.rle",
             "radarcol.mul",
             "skillgrp.mul",

--- a/Ultima/Helpers/MythicDecompress.cs
+++ b/Ultima/Helpers/MythicDecompress.cs
@@ -24,11 +24,16 @@ namespace Ultima.Helpers
             using (var reader = new BinaryReader(new MemoryStream(buffer)))
             {
                 var header = reader.ReadUInt32();
-                uint dataLength = header ^ 0x8E2C9A3D; // Must be equal to output length, error otherwise
+                uint dataLength = header ^ 0x8E2C9A3D;
 
-                // MoveToFront decoding
                 var list = reader.ReadBytes((int)(reader.BaseStream.Length - 4));
                 output = InternalDecompress(MoveToFrontCoding.Decode(list));
+
+                if (output.Length != dataLength)
+                {
+                    throw new InvalidDataException(
+                        $"Decompressed length {output.Length} does not match expected {dataLength}. File is not in compressed cliloc format.");
+                }
             }
 
             return output;

--- a/Ultima/MultiComponentList.cs
+++ b/Ultima/MultiComponentList.cs
@@ -39,6 +39,8 @@ namespace Ultima
         public MultiTileEntry[] SortedTiles { get; }
         public int Surface { get; private set; }
 
+        public static HashSet<ushort> DynamicItemIds { get; set; }
+
         public struct MultiTileEntry
         {
             public ushort ItemId;
@@ -433,7 +435,7 @@ namespace Ultima
                             var tempItem = new MultiTileEntry
                             {
                                 ItemId = 0xFFFF,
-                                Flags = 1,
+                                Flags = 0,
                                 Unk1 = 0
                             };
 
@@ -444,10 +446,17 @@ namespace Ultima
                                 {
                                     if (tempItem.ItemId != 0xFFFF)
                                     {
+                                        if (DynamicItemIds != null && DynamicItemIds.Contains(tempItem.ItemId))
+                                        {
+                                            tempItem.Flags = 1;
+                                        }
+
                                         SortedTiles[itemCount] = tempItem;
                                         ++itemCount;
                                     }
+
                                     tempItem.ItemId = 0xFFFF;
+                                    tempItem.Flags = 0;
                                 }
                                 else if (line.StartsWith("ID"))
                                 {
@@ -496,11 +505,18 @@ namespace Ultima
                                     }
                                 }
                             }
+
                             if (tempItem.ItemId != 0xFFFF)
                             {
+                                if (DynamicItemIds?.Contains(tempItem.ItemId) == true)
+                                {
+                                    tempItem.Flags = 1;
+                                }
+
                                 SortedTiles[itemCount] = tempItem;
                             }
                         }
+
                         break;
                     }
                 case Multis.ImportType.CSV: 

--- a/Ultima/MultiComponentList.cs
+++ b/Ultima/MultiComponentList.cs
@@ -517,6 +517,25 @@ namespace Ultima
                             }
                         }
 
+                        // WSC files from a live UO world use absolute world coordinates.
+                        // Tool-generated WSC files may already have relative offsets (possibly negative).
+                        // Heuristic: if both min coords are positive AND each exceeds the multi's own
+                        // extent, the file contains world coordinates and must be normalized.
+                        int extentX = _max.X - _min.X;
+                        int extentY = _max.Y - _min.Y;
+                        if (_min.X > 0 && _min.Y > 0 && _min.X > extentX && _min.Y > extentY)
+                        {
+                            for (int i = 0; i < SortedTiles.Length; ++i)
+                            {
+                                SortedTiles[i].OffsetX = (short)(SortedTiles[i].OffsetX - _min.X);
+                                SortedTiles[i].OffsetY = (short)(SortedTiles[i].OffsetY - _min.Y);
+                            }
+                            _max.X -= _min.X;
+                            _max.Y -= _min.Y;
+                            _min.X = 0;
+                            _min.Y = 0;
+                        }
+
                         break;
                     }
                 case Multis.ImportType.CSV: 

--- a/Ultima/Multis.cs
+++ b/Ultima/Multis.cs
@@ -13,6 +13,9 @@ namespace Ultima
         private static MultiComponentList[] _components = new MultiComponentList[MaximumMultiIndex];
         private static FileIndex _fileIndex = new FileIndex("Multi.idx", "Multi.mul", MaximumMultiIndex, 14);
 
+        private static MultiComponentList[] _uopComponents = new MultiComponentList[MaximumMultiIndex];
+        private static bool _uopLoaded;
+
         public enum ImportType
         {
             TXT,
@@ -33,6 +36,7 @@ namespace Ultima
         {
             _fileIndex = new FileIndex("Multi.idx", "Multi.mul", MaximumMultiIndex, 14);
             _components = new MultiComponentList[MaximumMultiIndex];
+            ReloadUop();
         }
 
         /// <summary>
@@ -233,6 +237,167 @@ namespace Ultima
                 }
 
                 return multiList;
+            }
+        }
+
+        public static bool HasUopFile => !string.IsNullOrEmpty(Files.GetFilePath("multicollection.uop"));
+
+        public static void ReloadUop()
+        {
+            _uopComponents = new MultiComponentList[MaximumMultiIndex];
+            _uopLoaded = false;
+        }
+
+        public static MultiComponentList GetUopComponents(int index)
+        {
+            if (!_uopLoaded)
+            {
+                LoadUop();
+            }
+
+            if (index >= 0 && index < _uopComponents.Length)
+            {
+                return _uopComponents[index] ?? MultiComponentList.Empty;
+            }
+
+            return MultiComponentList.Empty;
+        }
+
+        private static void LoadUop()
+        {
+            _uopLoaded = true;
+
+            string path = Files.GetFilePath("multicollection.uop");
+            if (path == null)
+            {
+                return;
+            }
+
+            try
+            {
+                using var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+                using var reader = new BinaryReader(fileStream);
+
+                uint magic = reader.ReadUInt32();
+                if (magic != 0x0050594D)
+                {
+                    return;
+                }
+
+                uint version = reader.ReadUInt32();
+                if (version > 5)
+                {
+                    return;
+                }
+
+                reader.ReadUInt32(); // signature
+                ulong nextTableOffset = reader.ReadUInt64();
+                reader.ReadUInt32(); // block capacity
+                reader.ReadUInt32(); // file count
+                reader.ReadUInt32(); // reserved
+                reader.ReadUInt32(); // reserved
+                reader.ReadUInt32(); // reserved
+
+                var entries = new List<(long dataOffset, uint compressedSize, uint decompressedSize)>();
+
+                ulong next = nextTableOffset;
+                while (next != 0)
+                {
+                    fileStream.Seek((long)next, SeekOrigin.Begin);
+                    int count = reader.ReadInt32();
+                    next = reader.ReadUInt64();
+
+                    for (int i = 0; i < count; i++)
+                    {
+                        ulong dataOffset = reader.ReadUInt64();
+                        uint headerSize = reader.ReadUInt32();
+                        uint compressedSize = reader.ReadUInt32();
+                        uint decompressedSize = reader.ReadUInt32();
+                        reader.ReadUInt64(); // hash
+                        reader.ReadUInt32(); // unknown
+                        ushort flag = reader.ReadUInt16();
+
+                        if (dataOffset == 0 || decompressedSize == 0)
+                        {
+                            continue;
+                        }
+
+                        if (flag == 0)
+                        {
+                            compressedSize = 0;
+                        }
+
+                        entries.Add(((long)(dataOffset + headerSize), compressedSize, decompressedSize));
+                    }
+                }
+
+                foreach (var (dataOffset, compressedSize, decompressedSize) in entries)
+                {
+                    fileStream.Seek(dataOffset, SeekOrigin.Begin);
+
+                    byte[] raw;
+                    if (compressedSize > 0)
+                    {
+                        byte[] compressed = reader.ReadBytes((int)compressedSize);
+                        (bool ok, byte[] decompressed) = UopUtils.Decompress(compressed);
+                        if (!ok)
+                        {
+                            continue;
+                        }
+
+                        raw = decompressed;
+                    }
+                    else
+                    {
+                        raw = reader.ReadBytes((int)decompressedSize);
+                    }
+
+                    using var memoryStream = new MemoryStream(raw);
+                    using var binaryReader = new BinaryReader(memoryStream);
+
+                    uint multiId = binaryReader.ReadUInt32();
+                    int componentCount = binaryReader.ReadInt32();
+
+                    if (multiId >= MaximumMultiIndex || componentCount <= 0)
+                    {
+                        continue;
+                    }
+
+                    var tiles = new List<MultiComponentList.MultiTileEntry>(componentCount);
+                    for (int j = 0; j < componentCount; j++)
+                    {
+                        ushort graphic = binaryReader.ReadUInt16();
+                        ushort ux = binaryReader.ReadUInt16();
+                        ushort uy = binaryReader.ReadUInt16();
+                        ushort uz = binaryReader.ReadUInt16();
+                        ushort uflags = binaryReader.ReadUInt16();
+                        int clilocsCount = binaryReader.ReadInt32();
+
+                        if (clilocsCount > 0)
+                        {
+                            binaryReader.BaseStream.Seek(clilocsCount * 4L, SeekOrigin.Current);
+                        }
+
+                        tiles.Add(new MultiComponentList.MultiTileEntry
+                        {
+                            ItemId = graphic,
+                            OffsetX = (short)ux,
+                            OffsetY = (short)uy,
+                            OffsetZ = (short)uz,
+                            Flags = uflags != 0 ? 0 : 1,
+                            Unk1 = 0
+                        });
+                    }
+
+                    if (tiles.Count > 0)
+                    {
+                        _uopComponents[multiId] = new MultiComponentList(tiles);
+                    }
+                }
+            }
+            catch
+            {
+                // leave array in its current partially-populated state
             }
         }
 

--- a/Ultima/StringList.cs
+++ b/Ultima/StringList.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -7,7 +8,7 @@ namespace Ultima
 {
     public sealed class StringList
     {
-        private readonly bool _decompress;
+        private bool _decompress;
         private int _header1;
         private short _header2;
 
@@ -51,45 +52,63 @@ namespace Ultima
                 return;
             }
 
-            Entries = new List<StringEntry>();
-            _stringTable = new Dictionary<int, string>();
-            _entryTable = new Dictionary<int, StringEntry>();
+            using var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+            byte[] buffer = new byte[fileStream.Length];
+            _ = fileStream.Read(buffer, 0, buffer.Length);
 
-            using (var fileStream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+            if (!TryParse(buffer, _decompress))
             {
-                byte[] buffer = new byte[fileStream.Length];
-                _ = fileStream.Read(buffer, 0, buffer.Length);
-
-                byte[] clilocData = _decompress
-                    ? MythicDecompress.Decompress(buffer)
-                    : buffer;
-
-                using (var reader = new BinaryReader(new MemoryStream(clilocData)))
+                bool fallback = !_decompress;
+                if (!TryParse(buffer, fallback))
                 {
-                    _header1 = reader.ReadInt32();
-                    _header2 = reader.ReadInt16();
-
-                    while (reader.BaseStream.Length != reader.BaseStream.Position)
-                    {
-                        int number = reader.ReadInt32();
-                        byte flag = reader.ReadByte();
-                        int length = reader.ReadInt16();
-
-                        if (length > _buffer.Length)
-                        {
-                            _buffer = new byte[(length + 1023) & ~1023];
-                        }
-
-                        reader.Read(_buffer, 0, length);
-                        string text = Encoding.UTF8.GetString(_buffer, 0, length);
-
-                        var se = new StringEntry(number, text, flag);
-                        Entries.Add(se);
-
-                        _stringTable[number] = text;
-                        _entryTable[number] = se;
-                    }
+                    throw new InvalidDataException($"Failed to parse cliloc file '{path}' in either compressed or uncompressed format.");
                 }
+                _decompress = fallback;
+            }
+        }
+
+        private bool TryParse(byte[] buffer, bool decompress)
+        {
+            try
+            {
+                byte[] clilocData = decompress ? MythicDecompress.Decompress(buffer) : buffer;
+
+                var entries = new List<StringEntry>();
+                var stringTable = new Dictionary<int, string>();
+                var entryTable = new Dictionary<int, StringEntry>();
+
+                using var reader = new BinaryReader(new MemoryStream(clilocData));
+                _header1 = reader.ReadInt32();
+                _header2 = reader.ReadInt16();
+
+                while (reader.BaseStream.Length != reader.BaseStream.Position)
+                {
+                    int number = reader.ReadInt32();
+                    byte flag = reader.ReadByte();
+                    int length = reader.ReadInt16();
+
+                    if (length > _buffer.Length)
+                    {
+                        _buffer = new byte[(length + 1023) & ~1023];
+                    }
+
+                    reader.Read(_buffer, 0, length);
+                    string text = Encoding.UTF8.GetString(_buffer, 0, length);
+
+                    var se = new StringEntry(number, text, flag);
+                    entries.Add(se);
+                    stringTable[number] = text;
+                    entryTable[number] = se;
+                }
+
+                Entries = entries;
+                _stringTable = stringTable;
+                _entryTable = entryTable;
+                return true;
+            }
+            catch
+            {
+                return false;
             }
         }
 

--- a/UoFiddler.Controls/Classes/DynamicItemsConfig.cs
+++ b/UoFiddler.Controls/Classes/DynamicItemsConfig.cs
@@ -1,0 +1,89 @@
+/***************************************************************************
+ *
+ * $Author: Turley
+ *
+ * "THE BEER-WARE LICENSE"
+ * As long as you retain this notice you can do whatever you want with
+ * this stuff. If we meet some day, and you think this stuff is worth it,
+ * you can buy me a beer in return.
+ *
+ ***************************************************************************/
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Xml;
+using Ultima;
+
+namespace UoFiddler.Controls.Classes
+{
+    public static class DynamicItemsConfig
+    {
+        private static bool _loaded;
+
+        public static void EnsureLoaded()
+        {
+            if (_loaded)
+            {
+                return;
+            }
+            _loaded = true;
+
+            string path = Path.Combine(Options.AppDataPath, "DynamicItems.xml");
+            if (!File.Exists(path))
+            {
+                Options.Logger?.Warning("DynamicItems.xml not found at {Path}", path);
+                return;
+            }
+
+            var ids = new HashSet<ushort>();
+            var doc = new XmlDocument();
+            doc.Load(path);
+
+            foreach (XmlNode node in doc.DocumentElement!.ChildNodes)
+            {
+                if (node is not XmlElement elem)
+                {
+                    continue;
+                }
+
+                switch (elem.LocalName)
+                {
+                    case "Item":
+                        if (TryParseId(elem.GetAttribute("id"), out ushort id))
+                        {
+                            ids.Add(id);
+                        }
+                        break;
+                    case "Range":
+                        if (TryParseId(elem.GetAttribute("from"), out ushort from) &&
+                            TryParseId(elem.GetAttribute("to"), out ushort to))
+                        {
+                            for (ushort i = from; i <= to; i++)
+                            {
+                                ids.Add(i);
+                            }
+                        }
+                        break;
+                }
+            }
+
+            MultiComponentList.DynamicItemIds = ids;
+        }
+
+        private static bool TryParseId(string value, out ushort result)
+        {
+            result = 0;
+            if (string.IsNullOrEmpty(value))
+            {
+                return false;
+            }
+            if (value.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+            {
+                return ushort.TryParse(value[2..], NumberStyles.HexNumber, null, out result);
+            }
+            return ushort.TryParse(value, out result);
+        }
+    }
+}

--- a/UoFiddler.Controls/Classes/Options.cs
+++ b/UoFiddler.Controls/Classes/Options.cs
@@ -29,11 +29,6 @@ namespace UoFiddler.Controls.Classes
         }
 
         /// <summary>
-        /// Should UOFiddler decompress cliloc files. For client version 7.104.0 or newer
-        /// </summary>
-        public static bool NewClilocFormat { get; set; }
-
-        /// <summary>
         /// Defines Element Width in ItemShow
         /// </summary>
         public static int ArtItemSizeWidth { get; set; } = 48;

--- a/UoFiddler.Controls/Forms/MultisHelpForm.Designer.cs
+++ b/UoFiddler.Controls/Forms/MultisHelpForm.Designer.cs
@@ -1,0 +1,99 @@
+namespace UoFiddler.Controls.Forms
+{
+    partial class MultisHelpForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            _listView = new System.Windows.Forms.ListView();
+            _columnKey = new System.Windows.Forms.ColumnHeader();
+            _columnAction = new System.Windows.Forms.ColumnHeader();
+            _btnClose = new System.Windows.Forms.Button();
+            SuspendLayout();
+            // 
+            // _listView
+            // 
+            _listView.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            _listView.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] { _columnKey, _columnAction });
+            _listView.FullRowSelect = true;
+            _listView.GridLines = true;
+            _listView.HeaderStyle = System.Windows.Forms.ColumnHeaderStyle.Nonclickable;
+            _listView.Location = new System.Drawing.Point(8, 8);
+            _listView.MultiSelect = false;
+            _listView.Name = "_listView";
+            _listView.Size = new System.Drawing.Size(618, 289);
+            _listView.TabIndex = 0;
+            _listView.UseCompatibleStateImageBehavior = false;
+            _listView.View = System.Windows.Forms.View.Details;
+            // 
+            // _columnKey
+            // 
+            _columnKey.Text = "Shortcut / Control";
+            _columnKey.Width = 180;
+            // 
+            // _columnAction
+            // 
+            _columnAction.Text = "Action";
+            _columnAction.Width = 420;
+            // 
+            // _btnClose
+            // 
+            _btnClose.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            _btnClose.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            _btnClose.Location = new System.Drawing.Point(551, 305);
+            _btnClose.Name = "_btnClose";
+            _btnClose.Size = new System.Drawing.Size(75, 27);
+            _btnClose.TabIndex = 1;
+            _btnClose.Text = "Close";
+            _btnClose.UseVisualStyleBackColor = true;
+            // 
+            // MultisHelpForm
+            // 
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            CancelButton = _btnClose;
+            ClientSize = new System.Drawing.Size(634, 341);
+            Controls.Add(_listView);
+            Controls.Add(_btnClose);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "MultisHelpForm";
+            Padding = new System.Windows.Forms.Padding(8);
+            ShowInTaskbar = false;
+            StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            Text = "Multis — Keyboard Shortcuts & Controls";
+            ResumeLayout(false);
+        }
+
+        #endregion
+
+        private System.Windows.Forms.ListView _listView;
+        private System.Windows.Forms.ColumnHeader _columnKey;
+        private System.Windows.Forms.ColumnHeader _columnAction;
+        private System.Windows.Forms.Button _btnClose;
+    }
+}

--- a/UoFiddler.Controls/Forms/MultisHelpForm.cs
+++ b/UoFiddler.Controls/Forms/MultisHelpForm.cs
@@ -1,0 +1,50 @@
+/***************************************************************************
+ *
+ * $Author: Turley
+ *
+ * "THE BEER-WARE LICENSE"
+ * As long as you retain this notice you can do whatever you want with
+ * this stuff. If we meet some day, and you think this stuff is worth it,
+ * you can buy me a beer in return.
+ *
+ ***************************************************************************/
+
+using System.Windows.Forms;
+
+namespace UoFiddler.Controls.Forms
+{
+    public partial class MultisHelpForm : Form
+    {
+        public MultisHelpForm()
+        {
+            InitializeComponent();
+            PopulateShortcuts();
+        }
+
+        private void PopulateShortcuts()
+        {
+            _listView.Groups.Add(new ListViewGroup("preview", "Preview"));
+            _listView.Groups.Add(new ListViewGroup("zoom", "Zoom (100% mode only)"));
+            _listView.Groups.Add(new ListViewGroup("pan", "Panning (100% mode only)"));
+
+            Add("Fit preview to window",        "Toggle button on toolbar — scales to fit or shows at 100% with scrollbars", "preview");
+
+            Add("Ctrl + Mouse Wheel",           "Zoom In / Out",         "zoom");
+            Add("Shift + = (Plus key)",         "Zoom In",               "zoom");
+            Add("- (Minus key)",                "Zoom Out",              "zoom");
+            Add("Numpad +",                     "Zoom In",               "zoom");
+            Add("Numpad -",                     "Zoom Out",              "zoom");
+            Add("Ctrl + 0",                     "Reset zoom to 100%",    "zoom");
+
+            Add("Left-click drag",              "Pan the view",          "pan");
+        }
+
+        private void Add(string key, string action, string groupKey)
+        {
+            var group = _listView.Groups[groupKey];
+            var item = new ListViewItem(key, group);
+            item.SubItems.Add(action);
+            _listView.Items.Add(item);
+        }
+    }
+}

--- a/UoFiddler.Controls/Forms/MultisHelpForm.resx
+++ b/UoFiddler.Controls/Forms/MultisHelpForm.resx
@@ -117,34 +117,4 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="contextMenuStrip2.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 54</value>
-  </metadata>
-  <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>172, 54</value>
-  </metadata>
-  <metadata name="contextMenuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>831, 17</value>
-  </metadata>
-  <metadata name="statusMulti.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>627, 17</value>
-  </metadata>
-  <metadata name="toolTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>740, 17</value>
-  </metadata>
-  <metadata name="colorDialog.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>277, 54</value>
-  </metadata>
-  <metadata name="contextMenuStripUopPic.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>309, 17</value>
-  </metadata>
-  <metadata name="contextMenuStripUop.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="toolStripUop.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>188, 17</value>
-  </metadata>
-  <metadata name="statusStripUop.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>496, 17</value>
-  </metadata>
 </root>

--- a/UoFiddler.Controls/UserControls/ClilocControl.cs
+++ b/UoFiddler.Controls/UserControls/ClilocControl.cs
@@ -54,18 +54,18 @@ namespace UoFiddler.Controls.UserControls
                 switch (value)
                 {
                     case 0:
-                        _cliloc = new StringList("enu", Options.NewClilocFormat);
+                        _cliloc = new StringList("enu", false);
                         break;
                     case 1:
-                        _cliloc = new StringList("deu", Options.NewClilocFormat);
+                        _cliloc = new StringList("deu", false);
                         break;
                     case 2:
                         TestCustomLang("cliloc.custom1");
-                        _cliloc = new StringList("custom1", Options.NewClilocFormat);
+                        _cliloc = new StringList("custom1", false);
                         break;
                     case 3:
                         TestCustomLang("cliloc.custom2");
-                        _cliloc = new StringList("custom2", Options.NewClilocFormat);
+                        _cliloc = new StringList("custom2", false);
                         break;
                 }
             }

--- a/UoFiddler.Controls/UserControls/MultisControl.Designer.cs
+++ b/UoFiddler.Controls/UserControls/MultisControl.Designer.cs
@@ -1,9 +1,9 @@
 /***************************************************************************
  *
  * $Author: Turley
- * 
+ *
  * "THE BEER-WARE LICENSE"
- * As long as you retain this notice you can do whatever you want with 
+ * As long as you retain this notice you can do whatever you want with
  * this stuff. If we meet some day, and you think this stuff is worth it,
  * you can buy me a beer in return.
  *
@@ -13,12 +13,12 @@ namespace UoFiddler.Controls.UserControls
 {
     partial class MultisControl
     {
-        /// <summary> 
+        /// <summary>
         /// Required designer variable.
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary> 
+        /// <summary>
         /// Clean up any resources being used.
         /// </summary>
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
@@ -71,11 +71,14 @@ namespace UoFiddler.Controls.UserControls
             toXMLFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
             saveToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            fitModeToolStripMenuItem = new System.Windows.Forms.ToolStripButton();
+            helpToolStripButton = new System.Windows.Forms.ToolStripButton();
             tabControl3 = new System.Windows.Forms.TabControl();
             tabPage5 = new System.Windows.Forms.TabPage();
             splitContainer3 = new System.Windows.Forms.SplitContainer();
             HeightChangeMulti = new System.Windows.Forms.TrackBar();
             splitContainer4 = new System.Windows.Forms.SplitContainer();
+            panelMultiScroll = new System.Windows.Forms.Panel();
             MultiPictureBox = new System.Windows.Forms.PictureBox();
             contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(components);
             extractImageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -89,6 +92,48 @@ namespace UoFiddler.Controls.UserControls
             MultiComponentBox = new System.Windows.Forms.RichTextBox();
             toolTip = new System.Windows.Forms.ToolTip(components);
             colorDialog = new System.Windows.Forms.ColorDialog();
+            panelUopScroll = new System.Windows.Forms.Panel();
+            UopPictureBox = new System.Windows.Forms.PictureBox();
+            contextMenuStripUopPic = new System.Windows.Forms.ContextMenuStrip(components);
+            uopExtractImageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            uopAsBmpPicToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            uopAsTiffPicToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            uopAsJpgPicToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            uopAsPngPicToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            uopFitModeToolStripMenuItem = new System.Windows.Forms.ToolStripButton();
+            uopHelpToolStripButton = new System.Windows.Forms.ToolStripButton();
+            tabControlSource = new System.Windows.Forms.TabControl();
+            tabPageMul = new System.Windows.Forms.TabPage();
+            tabPageUop = new System.Windows.Forms.TabPage();
+            splitContainerUop = new System.Windows.Forms.SplitContainer();
+            treeViewUop = new System.Windows.Forms.TreeView();
+            contextMenuStripUop = new System.Windows.Forms.ContextMenuStrip(components);
+            uopExportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            uopToUOAToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            uopToWscToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            uopToCsvToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripUop = new System.Windows.Forms.ToolStrip();
+            toolStripDropDownUop = new System.Windows.Forms.ToolStripDropDownButton();
+            uopExportAllImagesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            uopAsBmpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            uopAsTiffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            uopAsJpgToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            uopAsPngToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            uopToolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            uopExportAllPartsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            uopToTextfileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            uopToUOAFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            uopToWSCFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            uopToCSVFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            tabControlUopDetail = new System.Windows.Forms.TabControl();
+            tabPageUopPreview = new System.Windows.Forms.TabPage();
+            splitContainerUop3 = new System.Windows.Forms.SplitContainer();
+            HeightChangeUop = new System.Windows.Forms.TrackBar();
+            splitContainerUop4 = new System.Windows.Forms.SplitContainer();
+            statusStripUop = new System.Windows.Forms.StatusStrip();
+            StatusUopText = new System.Windows.Forms.ToolStripStatusLabel();
+            tabPageUopComponents = new System.Windows.Forms.TabPage();
+            UopComponentBox = new System.Windows.Forms.RichTextBox();
             ((System.ComponentModel.ISupportInitialize)splitContainer2).BeginInit();
             splitContainer2.Panel1.SuspendLayout();
             splitContainer2.Panel2.SuspendLayout();
@@ -106,10 +151,36 @@ namespace UoFiddler.Controls.UserControls
             splitContainer4.Panel1.SuspendLayout();
             splitContainer4.Panel2.SuspendLayout();
             splitContainer4.SuspendLayout();
+            panelMultiScroll.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)MultiPictureBox).BeginInit();
             contextMenuStrip1.SuspendLayout();
             statusMulti.SuspendLayout();
             tabPage6.SuspendLayout();
+            panelUopScroll.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)UopPictureBox).BeginInit();
+            contextMenuStripUopPic.SuspendLayout();
+            tabControlSource.SuspendLayout();
+            tabPageMul.SuspendLayout();
+            tabPageUop.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)splitContainerUop).BeginInit();
+            splitContainerUop.Panel1.SuspendLayout();
+            splitContainerUop.Panel2.SuspendLayout();
+            splitContainerUop.SuspendLayout();
+            contextMenuStripUop.SuspendLayout();
+            toolStripUop.SuspendLayout();
+            tabControlUopDetail.SuspendLayout();
+            tabPageUopPreview.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)splitContainerUop3).BeginInit();
+            splitContainerUop3.Panel1.SuspendLayout();
+            splitContainerUop3.Panel2.SuspendLayout();
+            splitContainerUop3.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)HeightChangeUop).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)splitContainerUop4).BeginInit();
+            splitContainerUop4.Panel1.SuspendLayout();
+            splitContainerUop4.Panel2.SuspendLayout();
+            splitContainerUop4.SuspendLayout();
+            statusStripUop.SuspendLayout();
+            tabPageUopComponents.SuspendLayout();
             SuspendLayout();
             // 
             // splitContainer2
@@ -127,7 +198,7 @@ namespace UoFiddler.Controls.UserControls
             // splitContainer2.Panel2
             // 
             splitContainer2.Panel2.Controls.Add(tabControl3);
-            splitContainer2.Size = new System.Drawing.Size(755, 442);
+            splitContainer2.Size = new System.Drawing.Size(747, 414);
             splitContainer2.SplitterDistance = 245;
             splitContainer2.SplitterWidth = 5;
             splitContainer2.TabIndex = 1;
@@ -141,7 +212,7 @@ namespace UoFiddler.Controls.UserControls
             TreeViewMulti.Margin = new System.Windows.Forms.Padding(0);
             TreeViewMulti.Name = "TreeViewMulti";
             TreeViewMulti.ShowNodeToolTips = true;
-            TreeViewMulti.Size = new System.Drawing.Size(245, 417);
+            TreeViewMulti.Size = new System.Drawing.Size(245, 389);
             TreeViewMulti.TabIndex = 0;
             TreeViewMulti.AfterSelect += AfterSelect_Multi;
             // 
@@ -218,7 +289,7 @@ namespace UoFiddler.Controls.UserControls
             // toolStrip1
             // 
             toolStrip1.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
-            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { toolStripDropDownButton1 });
+            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { toolStripDropDownButton1, fitModeToolStripMenuItem, helpToolStripButton });
             toolStrip1.Location = new System.Drawing.Point(0, 0);
             toolStrip1.Name = "toolStrip1";
             toolStrip1.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
@@ -355,6 +426,27 @@ namespace UoFiddler.Controls.UserControls
             saveToolStripMenuItem1.Text = "Save";
             saveToolStripMenuItem1.Click += OnClickSave;
             // 
+            // fitModeToolStripMenuItem
+            // 
+            fitModeToolStripMenuItem.Checked = true;
+            fitModeToolStripMenuItem.CheckOnClick = true;
+            fitModeToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            fitModeToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            fitModeToolStripMenuItem.Name = "fitModeToolStripMenuItem";
+            fitModeToolStripMenuItem.Size = new System.Drawing.Size(127, 22);
+            fitModeToolStripMenuItem.Text = "Fit preview to window";
+            fitModeToolStripMenuItem.ToolTipText = "When checked the preview scales to fit. When unchecked it shows 100% with scrollbars.";
+            fitModeToolStripMenuItem.CheckedChanged += OnToggleFitMode;
+            // 
+            // helpToolStripButton
+            // 
+            helpToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            helpToolStripButton.Name = "helpToolStripButton";
+            helpToolStripButton.Size = new System.Drawing.Size(36, 22);
+            helpToolStripButton.Text = "Help";
+            helpToolStripButton.ToolTipText = "Show keyboard shortcuts and controls";
+            helpToolStripButton.Click += OnClickHelp;
+            // 
             // tabControl3
             // 
             tabControl3.Controls.Add(tabPage5);
@@ -364,7 +456,7 @@ namespace UoFiddler.Controls.UserControls
             tabControl3.Margin = new System.Windows.Forms.Padding(0);
             tabControl3.Name = "tabControl3";
             tabControl3.SelectedIndex = 0;
-            tabControl3.Size = new System.Drawing.Size(505, 442);
+            tabControl3.Size = new System.Drawing.Size(497, 414);
             tabControl3.TabIndex = 1;
             // 
             // tabPage5
@@ -374,7 +466,7 @@ namespace UoFiddler.Controls.UserControls
             tabPage5.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             tabPage5.Name = "tabPage5";
             tabPage5.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            tabPage5.Size = new System.Drawing.Size(497, 414);
+            tabPage5.Size = new System.Drawing.Size(489, 386);
             tabPage5.TabIndex = 0;
             tabPage5.Text = "Graphic";
             tabPage5.UseVisualStyleBackColor = true;
@@ -394,7 +486,7 @@ namespace UoFiddler.Controls.UserControls
             // splitContainer3.Panel2
             // 
             splitContainer3.Panel2.Controls.Add(splitContainer4);
-            splitContainer3.Size = new System.Drawing.Size(489, 408);
+            splitContainer3.Size = new System.Drawing.Size(481, 380);
             splitContainer3.SplitterDistance = 41;
             splitContainer3.SplitterWidth = 1;
             splitContainer3.TabIndex = 0;
@@ -407,7 +499,7 @@ namespace UoFiddler.Controls.UserControls
             HeightChangeMulti.MaximumSize = new System.Drawing.Size(0, 38);
             HeightChangeMulti.MinimumSize = new System.Drawing.Size(0, 38);
             HeightChangeMulti.Name = "HeightChangeMulti";
-            HeightChangeMulti.Size = new System.Drawing.Size(489, 38);
+            HeightChangeMulti.Size = new System.Drawing.Size(481, 38);
             HeightChangeMulti.TabIndex = 0;
             HeightChangeMulti.ValueChanged += OnValue_HeightChangeMulti;
             // 
@@ -421,16 +513,28 @@ namespace UoFiddler.Controls.UserControls
             // 
             // splitContainer4.Panel1
             // 
-            splitContainer4.Panel1.Controls.Add(MultiPictureBox);
+            splitContainer4.Panel1.Controls.Add(panelMultiScroll);
             // 
             // splitContainer4.Panel2
             // 
             splitContainer4.Panel2.Controls.Add(statusMulti);
             splitContainer4.Panel2MinSize = 22;
-            splitContainer4.Size = new System.Drawing.Size(489, 366);
-            splitContainer4.SplitterDistance = 322;
+            splitContainer4.Size = new System.Drawing.Size(481, 338);
+            splitContainer4.SplitterDistance = 308;
             splitContainer4.SplitterWidth = 1;
             splitContainer4.TabIndex = 1;
+            // 
+            // panelMultiScroll
+            // 
+            panelMultiScroll.AutoScroll = true;
+            panelMultiScroll.Controls.Add(MultiPictureBox);
+            panelMultiScroll.Dock = System.Windows.Forms.DockStyle.Fill;
+            panelMultiScroll.Location = new System.Drawing.Point(0, 0);
+            panelMultiScroll.Margin = new System.Windows.Forms.Padding(0);
+            panelMultiScroll.Name = "panelMultiScroll";
+            panelMultiScroll.Size = new System.Drawing.Size(481, 308);
+            panelMultiScroll.TabIndex = 0;
+            panelMultiScroll.Resize += OnPanelMultiScroll_Resize;
             // 
             // MultiPictureBox
             // 
@@ -440,10 +544,13 @@ namespace UoFiddler.Controls.UserControls
             MultiPictureBox.Location = new System.Drawing.Point(0, 0);
             MultiPictureBox.Margin = new System.Windows.Forms.Padding(0);
             MultiPictureBox.Name = "MultiPictureBox";
-            MultiPictureBox.Size = new System.Drawing.Size(489, 322);
+            MultiPictureBox.Size = new System.Drawing.Size(481, 308);
             MultiPictureBox.TabIndex = 0;
             MultiPictureBox.TabStop = false;
             MultiPictureBox.Paint += OnPaint_MultiPic;
+            MultiPictureBox.MouseDown += OnMulPan_MouseDown;
+            MultiPictureBox.MouseMove += OnMulPan_MouseMove;
+            MultiPictureBox.MouseUp += OnPan_MouseUp;
             // 
             // contextMenuStrip1
             // 
@@ -489,10 +596,10 @@ namespace UoFiddler.Controls.UserControls
             // statusMulti
             // 
             statusMulti.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { StatusMultiText });
-            statusMulti.Location = new System.Drawing.Point(0, 21);
+            statusMulti.Location = new System.Drawing.Point(0, 7);
             statusMulti.Name = "statusMulti";
             statusMulti.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
-            statusMulti.Size = new System.Drawing.Size(489, 22);
+            statusMulti.Size = new System.Drawing.Size(481, 22);
             statusMulti.TabIndex = 0;
             statusMulti.Text = "statusStrip2";
             // 
@@ -509,7 +616,7 @@ namespace UoFiddler.Controls.UserControls
             tabPage6.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             tabPage6.Name = "tabPage6";
             tabPage6.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            tabPage6.Size = new System.Drawing.Size(497, 414);
+            tabPage6.Size = new System.Drawing.Size(489, 386);
             tabPage6.TabIndex = 1;
             tabPage6.Text = "Component List";
             tabPage6.UseVisualStyleBackColor = true;
@@ -521,7 +628,7 @@ namespace UoFiddler.Controls.UserControls
             MultiComponentBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             MultiComponentBox.Name = "MultiComponentBox";
             MultiComponentBox.ReadOnly = true;
-            MultiComponentBox.Size = new System.Drawing.Size(489, 408);
+            MultiComponentBox.Size = new System.Drawing.Size(481, 380);
             MultiComponentBox.TabIndex = 0;
             MultiComponentBox.Text = "";
             // 
@@ -529,11 +636,412 @@ namespace UoFiddler.Controls.UserControls
             // 
             colorDialog.Color = System.Drawing.Color.White;
             // 
+            // panelUopScroll
+            // 
+            panelUopScroll.AutoScroll = true;
+            panelUopScroll.Controls.Add(UopPictureBox);
+            panelUopScroll.Dock = System.Windows.Forms.DockStyle.Fill;
+            panelUopScroll.Location = new System.Drawing.Point(0, 0);
+            panelUopScroll.Margin = new System.Windows.Forms.Padding(0);
+            panelUopScroll.Name = "panelUopScroll";
+            panelUopScroll.Size = new System.Drawing.Size(481, 308);
+            panelUopScroll.TabIndex = 0;
+            panelUopScroll.Resize += OnPanelUopScroll_Resize;
+            // 
+            // UopPictureBox
+            // 
+            UopPictureBox.BackColor = System.Drawing.Color.White;
+            UopPictureBox.ContextMenuStrip = contextMenuStripUopPic;
+            UopPictureBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            UopPictureBox.Location = new System.Drawing.Point(0, 0);
+            UopPictureBox.Margin = new System.Windows.Forms.Padding(0);
+            UopPictureBox.Name = "UopPictureBox";
+            UopPictureBox.Size = new System.Drawing.Size(481, 308);
+            UopPictureBox.TabIndex = 0;
+            UopPictureBox.TabStop = false;
+            UopPictureBox.Paint += OnPaint_UopMultiPic;
+            UopPictureBox.MouseDown += OnUopPan_MouseDown;
+            UopPictureBox.MouseMove += OnUopPan_MouseMove;
+            UopPictureBox.MouseUp += OnPan_MouseUp;
+            // 
+            // contextMenuStripUopPic
+            // 
+            contextMenuStripUopPic.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { uopExtractImageToolStripMenuItem });
+            contextMenuStripUopPic.Name = "contextMenuStripUopPic";
+            contextMenuStripUopPic.Size = new System.Drawing.Size(153, 26);
+            // 
+            // uopExtractImageToolStripMenuItem
+            // 
+            uopExtractImageToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { uopAsBmpPicToolStripMenuItem, uopAsTiffPicToolStripMenuItem, uopAsJpgPicToolStripMenuItem, uopAsPngPicToolStripMenuItem });
+            uopExtractImageToolStripMenuItem.Name = "uopExtractImageToolStripMenuItem";
+            uopExtractImageToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            uopExtractImageToolStripMenuItem.Text = "extract Image..";
+            // 
+            // uopAsBmpPicToolStripMenuItem
+            // 
+            uopAsBmpPicToolStripMenuItem.Name = "uopAsBmpPicToolStripMenuItem";
+            uopAsBmpPicToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            uopAsBmpPicToolStripMenuItem.Text = "As Bmp";
+            uopAsBmpPicToolStripMenuItem.Click += UopExtract_Image_ClickBmp;
+            // 
+            // uopAsTiffPicToolStripMenuItem
+            // 
+            uopAsTiffPicToolStripMenuItem.Name = "uopAsTiffPicToolStripMenuItem";
+            uopAsTiffPicToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            uopAsTiffPicToolStripMenuItem.Text = "As Tiff";
+            uopAsTiffPicToolStripMenuItem.Click += UopExtract_Image_ClickTiff;
+            // 
+            // uopAsJpgPicToolStripMenuItem
+            // 
+            uopAsJpgPicToolStripMenuItem.Name = "uopAsJpgPicToolStripMenuItem";
+            uopAsJpgPicToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            uopAsJpgPicToolStripMenuItem.Text = "As Jpg";
+            uopAsJpgPicToolStripMenuItem.Click += UopExtract_Image_ClickJpg;
+            // 
+            // uopAsPngPicToolStripMenuItem
+            // 
+            uopAsPngPicToolStripMenuItem.Name = "uopAsPngPicToolStripMenuItem";
+            uopAsPngPicToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            uopAsPngPicToolStripMenuItem.Text = "As Png";
+            uopAsPngPicToolStripMenuItem.Click += UopExtract_Image_ClickPng;
+            // 
+            // uopFitModeToolStripMenuItem
+            // 
+            uopFitModeToolStripMenuItem.Checked = true;
+            uopFitModeToolStripMenuItem.CheckOnClick = true;
+            uopFitModeToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            uopFitModeToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            uopFitModeToolStripMenuItem.Name = "uopFitModeToolStripMenuItem";
+            uopFitModeToolStripMenuItem.Size = new System.Drawing.Size(127, 22);
+            uopFitModeToolStripMenuItem.Text = "Fit preview to window";
+            uopFitModeToolStripMenuItem.ToolTipText = "When checked the preview scales to fit. When unchecked it shows 100% with scrollbars.";
+            uopFitModeToolStripMenuItem.CheckedChanged += OnToggleFitMode;
+            // 
+            // uopHelpToolStripButton
+            // 
+            uopHelpToolStripButton.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            uopHelpToolStripButton.Name = "uopHelpToolStripButton";
+            uopHelpToolStripButton.Size = new System.Drawing.Size(36, 22);
+            uopHelpToolStripButton.Text = "Help";
+            uopHelpToolStripButton.ToolTipText = "Show keyboard shortcuts and controls";
+            uopHelpToolStripButton.Click += OnClickHelp;
+            // 
+            // tabControlSource
+            // 
+            tabControlSource.Controls.Add(tabPageMul);
+            tabControlSource.Controls.Add(tabPageUop);
+            tabControlSource.Dock = System.Windows.Forms.DockStyle.Fill;
+            tabControlSource.Location = new System.Drawing.Point(0, 0);
+            tabControlSource.Margin = new System.Windows.Forms.Padding(0);
+            tabControlSource.Name = "tabControlSource";
+            tabControlSource.SelectedIndex = 0;
+            tabControlSource.Size = new System.Drawing.Size(755, 442);
+            tabControlSource.TabIndex = 0;
+            // 
+            // tabPageMul
+            // 
+            tabPageMul.Controls.Add(splitContainer2);
+            tabPageMul.Location = new System.Drawing.Point(4, 24);
+            tabPageMul.Margin = new System.Windows.Forms.Padding(0);
+            tabPageMul.Name = "tabPageMul";
+            tabPageMul.Size = new System.Drawing.Size(747, 414);
+            tabPageMul.TabIndex = 0;
+            tabPageMul.Text = "multi.mul";
+            tabPageMul.UseVisualStyleBackColor = true;
+            // 
+            // tabPageUop
+            // 
+            tabPageUop.Controls.Add(splitContainerUop);
+            tabPageUop.Location = new System.Drawing.Point(4, 24);
+            tabPageUop.Margin = new System.Windows.Forms.Padding(0);
+            tabPageUop.Name = "tabPageUop";
+            tabPageUop.Size = new System.Drawing.Size(747, 414);
+            tabPageUop.TabIndex = 1;
+            tabPageUop.Text = "MultiCollection.uop";
+            tabPageUop.UseVisualStyleBackColor = true;
+            // 
+            // splitContainerUop
+            // 
+            splitContainerUop.Dock = System.Windows.Forms.DockStyle.Fill;
+            splitContainerUop.Location = new System.Drawing.Point(0, 0);
+            splitContainerUop.Margin = new System.Windows.Forms.Padding(0);
+            splitContainerUop.Name = "splitContainerUop";
+            // 
+            // splitContainerUop.Panel1
+            // 
+            splitContainerUop.Panel1.Controls.Add(treeViewUop);
+            splitContainerUop.Panel1.Controls.Add(toolStripUop);
+            // 
+            // splitContainerUop.Panel2
+            // 
+            splitContainerUop.Panel2.Controls.Add(tabControlUopDetail);
+            splitContainerUop.Size = new System.Drawing.Size(747, 414);
+            splitContainerUop.SplitterDistance = 245;
+            splitContainerUop.SplitterWidth = 5;
+            splitContainerUop.TabIndex = 0;
+            // 
+            // treeViewUop
+            // 
+            treeViewUop.ContextMenuStrip = contextMenuStripUop;
+            treeViewUop.Dock = System.Windows.Forms.DockStyle.Fill;
+            treeViewUop.HideSelection = false;
+            treeViewUop.Location = new System.Drawing.Point(0, 25);
+            treeViewUop.Margin = new System.Windows.Forms.Padding(0);
+            treeViewUop.Name = "treeViewUop";
+            treeViewUop.ShowNodeToolTips = true;
+            treeViewUop.Size = new System.Drawing.Size(245, 389);
+            treeViewUop.TabIndex = 0;
+            treeViewUop.AfterSelect += AfterSelect_UopMulti;
+            // 
+            // contextMenuStripUop
+            // 
+            contextMenuStripUop.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { uopExportToolStripMenuItem });
+            contextMenuStripUop.Name = "contextMenuStripUop";
+            contextMenuStripUop.Size = new System.Drawing.Size(115, 26);
+            // 
+            // uopExportToolStripMenuItem
+            // 
+            uopExportToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { uopToUOAToolStripMenuItem, uopToWscToolStripMenuItem, uopToCsvToolStripMenuItem });
+            uopExportToolStripMenuItem.Name = "uopExportToolStripMenuItem";
+            uopExportToolStripMenuItem.Size = new System.Drawing.Size(114, 22);
+            uopExportToolStripMenuItem.Text = "Export..";
+            // 
+            // uopToUOAToolStripMenuItem
+            // 
+            uopToUOAToolStripMenuItem.Name = "uopToUOAToolStripMenuItem";
+            uopToUOAToolStripMenuItem.Size = new System.Drawing.Size(114, 22);
+            uopToUOAToolStripMenuItem.Text = "To UOA";
+            uopToUOAToolStripMenuItem.Click += OnUopExportUOAFile;
+            // 
+            // uopToWscToolStripMenuItem
+            // 
+            uopToWscToolStripMenuItem.Name = "uopToWscToolStripMenuItem";
+            uopToWscToolStripMenuItem.Size = new System.Drawing.Size(114, 22);
+            uopToWscToolStripMenuItem.Text = "To WSC";
+            uopToWscToolStripMenuItem.Click += OnUopExportWscFile;
+            // 
+            // uopToCsvToolStripMenuItem
+            // 
+            uopToCsvToolStripMenuItem.Name = "uopToCsvToolStripMenuItem";
+            uopToCsvToolStripMenuItem.Size = new System.Drawing.Size(114, 22);
+            uopToCsvToolStripMenuItem.Text = "To CSV";
+            uopToCsvToolStripMenuItem.Click += OnUopExportCsvFile;
+            // 
+            // toolStripUop
+            // 
+            toolStripUop.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
+            toolStripUop.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { toolStripDropDownUop, uopFitModeToolStripMenuItem, uopHelpToolStripButton });
+            toolStripUop.Location = new System.Drawing.Point(0, 0);
+            toolStripUop.Name = "toolStripUop";
+            toolStripUop.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
+            toolStripUop.Size = new System.Drawing.Size(245, 25);
+            toolStripUop.TabIndex = 1;
+            toolStripUop.Text = "toolStripUop";
+            // 
+            // toolStripDropDownUop
+            // 
+            toolStripDropDownUop.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            toolStripDropDownUop.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { uopExportAllImagesToolStripMenuItem, uopToolStripSeparator1, uopExportAllPartsToolStripMenuItem });
+            toolStripDropDownUop.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripDropDownUop.Name = "toolStripDropDownUop";
+            toolStripDropDownUop.Size = new System.Drawing.Size(45, 22);
+            toolStripDropDownUop.Text = "Misc";
+            // 
+            // uopExportAllImagesToolStripMenuItem
+            // 
+            uopExportAllImagesToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { uopAsBmpToolStripMenuItem, uopAsTiffToolStripMenuItem, uopAsJpgToolStripMenuItem, uopAsPngToolStripMenuItem });
+            uopExportAllImagesToolStripMenuItem.Name = "uopExportAllImagesToolStripMenuItem";
+            uopExportAllImagesToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
+            uopExportAllImagesToolStripMenuItem.Text = "Export All Image";
+            // 
+            // uopAsBmpToolStripMenuItem
+            // 
+            uopAsBmpToolStripMenuItem.Name = "uopAsBmpToolStripMenuItem";
+            uopAsBmpToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            uopAsBmpToolStripMenuItem.Text = "As Bmp";
+            uopAsBmpToolStripMenuItem.Click += OnUopClick_SaveAllBmp;
+            // 
+            // uopAsTiffToolStripMenuItem
+            // 
+            uopAsTiffToolStripMenuItem.Name = "uopAsTiffToolStripMenuItem";
+            uopAsTiffToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            uopAsTiffToolStripMenuItem.Text = "As Tiff";
+            uopAsTiffToolStripMenuItem.Click += OnUopClick_SaveAllTiff;
+            // 
+            // uopAsJpgToolStripMenuItem
+            // 
+            uopAsJpgToolStripMenuItem.Name = "uopAsJpgToolStripMenuItem";
+            uopAsJpgToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            uopAsJpgToolStripMenuItem.Text = "As Jpg";
+            uopAsJpgToolStripMenuItem.Click += OnUopClick_SaveAllJpg;
+            // 
+            // uopAsPngToolStripMenuItem
+            // 
+            uopAsPngToolStripMenuItem.Name = "uopAsPngToolStripMenuItem";
+            uopAsPngToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            uopAsPngToolStripMenuItem.Text = "As Png";
+            uopAsPngToolStripMenuItem.Click += OnUopClick_SaveAllPng;
+            // 
+            // uopToolStripSeparator1
+            // 
+            uopToolStripSeparator1.Name = "uopToolStripSeparator1";
+            uopToolStripSeparator1.Size = new System.Drawing.Size(158, 6);
+            // 
+            // uopExportAllPartsToolStripMenuItem
+            // 
+            uopExportAllPartsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { uopToTextfileToolStripMenuItem, uopToUOAFileToolStripMenuItem, uopToWSCFileToolStripMenuItem, uopToCSVFileToolStripMenuItem });
+            uopExportAllPartsToolStripMenuItem.Name = "uopExportAllPartsToolStripMenuItem";
+            uopExportAllPartsToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
+            uopExportAllPartsToolStripMenuItem.Text = "Export All Parts";
+            // 
+            // uopToTextfileToolStripMenuItem
+            // 
+            uopToTextfileToolStripMenuItem.Name = "uopToTextfileToolStripMenuItem";
+            uopToTextfileToolStripMenuItem.Size = new System.Drawing.Size(135, 22);
+            uopToTextfileToolStripMenuItem.Text = "To Textfile";
+            uopToTextfileToolStripMenuItem.Click += OnUopExportTextFile;
+            // 
+            // uopToUOAFileToolStripMenuItem
+            // 
+            uopToUOAFileToolStripMenuItem.Name = "uopToUOAFileToolStripMenuItem";
+            uopToUOAFileToolStripMenuItem.Size = new System.Drawing.Size(135, 22);
+            uopToUOAFileToolStripMenuItem.Text = "To UOA File";
+            uopToUOAFileToolStripMenuItem.Click += OnUopClick_SaveAllUOA;
+            // 
+            // uopToWSCFileToolStripMenuItem
+            // 
+            uopToWSCFileToolStripMenuItem.Name = "uopToWSCFileToolStripMenuItem";
+            uopToWSCFileToolStripMenuItem.Size = new System.Drawing.Size(135, 22);
+            uopToWSCFileToolStripMenuItem.Text = "To WSC File";
+            uopToWSCFileToolStripMenuItem.Click += OnUopClick_SaveAllWSC;
+            // 
+            // uopToCSVFileToolStripMenuItem
+            // 
+            uopToCSVFileToolStripMenuItem.Name = "uopToCSVFileToolStripMenuItem";
+            uopToCSVFileToolStripMenuItem.Size = new System.Drawing.Size(135, 22);
+            uopToCSVFileToolStripMenuItem.Text = "To CSV File";
+            uopToCSVFileToolStripMenuItem.Click += OnUopClick_SaveAllCSV;
+            // 
+            // tabControlUopDetail
+            // 
+            tabControlUopDetail.Controls.Add(tabPageUopPreview);
+            tabControlUopDetail.Controls.Add(tabPageUopComponents);
+            tabControlUopDetail.Dock = System.Windows.Forms.DockStyle.Fill;
+            tabControlUopDetail.Location = new System.Drawing.Point(0, 0);
+            tabControlUopDetail.Margin = new System.Windows.Forms.Padding(0);
+            tabControlUopDetail.Name = "tabControlUopDetail";
+            tabControlUopDetail.SelectedIndex = 0;
+            tabControlUopDetail.Size = new System.Drawing.Size(497, 414);
+            tabControlUopDetail.TabIndex = 0;
+            // 
+            // tabPageUopPreview
+            // 
+            tabPageUopPreview.Controls.Add(splitContainerUop3);
+            tabPageUopPreview.Location = new System.Drawing.Point(4, 24);
+            tabPageUopPreview.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            tabPageUopPreview.Name = "tabPageUopPreview";
+            tabPageUopPreview.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            tabPageUopPreview.Size = new System.Drawing.Size(489, 386);
+            tabPageUopPreview.TabIndex = 0;
+            tabPageUopPreview.Text = "Graphic";
+            tabPageUopPreview.UseVisualStyleBackColor = true;
+            // 
+            // splitContainerUop3
+            // 
+            splitContainerUop3.Dock = System.Windows.Forms.DockStyle.Fill;
+            splitContainerUop3.Location = new System.Drawing.Point(4, 3);
+            splitContainerUop3.Margin = new System.Windows.Forms.Padding(0);
+            splitContainerUop3.Name = "splitContainerUop3";
+            splitContainerUop3.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainerUop3.Panel1
+            // 
+            splitContainerUop3.Panel1.Controls.Add(HeightChangeUop);
+            // 
+            // splitContainerUop3.Panel2
+            // 
+            splitContainerUop3.Panel2.Controls.Add(splitContainerUop4);
+            splitContainerUop3.Size = new System.Drawing.Size(481, 380);
+            splitContainerUop3.SplitterDistance = 41;
+            splitContainerUop3.SplitterWidth = 1;
+            splitContainerUop3.TabIndex = 0;
+            // 
+            // HeightChangeUop
+            // 
+            HeightChangeUop.Dock = System.Windows.Forms.DockStyle.Fill;
+            HeightChangeUop.Location = new System.Drawing.Point(0, 0);
+            HeightChangeUop.Margin = new System.Windows.Forms.Padding(0);
+            HeightChangeUop.MaximumSize = new System.Drawing.Size(0, 38);
+            HeightChangeUop.MinimumSize = new System.Drawing.Size(0, 38);
+            HeightChangeUop.Name = "HeightChangeUop";
+            HeightChangeUop.Size = new System.Drawing.Size(481, 38);
+            HeightChangeUop.TabIndex = 0;
+            HeightChangeUop.ValueChanged += OnValue_HeightChangeUop;
+            // 
+            // splitContainerUop4
+            // 
+            splitContainerUop4.Dock = System.Windows.Forms.DockStyle.Fill;
+            splitContainerUop4.Location = new System.Drawing.Point(0, 0);
+            splitContainerUop4.Margin = new System.Windows.Forms.Padding(0);
+            splitContainerUop4.Name = "splitContainerUop4";
+            splitContainerUop4.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainerUop4.Panel1
+            // 
+            splitContainerUop4.Panel1.Controls.Add(panelUopScroll);
+            // 
+            // splitContainerUop4.Panel2
+            // 
+            splitContainerUop4.Panel2.Controls.Add(statusStripUop);
+            splitContainerUop4.Panel2MinSize = 22;
+            splitContainerUop4.Size = new System.Drawing.Size(481, 338);
+            splitContainerUop4.SplitterDistance = 308;
+            splitContainerUop4.SplitterWidth = 1;
+            splitContainerUop4.TabIndex = 1;
+            // 
+            // statusStripUop
+            // 
+            statusStripUop.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { StatusUopText });
+            statusStripUop.Location = new System.Drawing.Point(0, 7);
+            statusStripUop.Name = "statusStripUop";
+            statusStripUop.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
+            statusStripUop.Size = new System.Drawing.Size(481, 22);
+            statusStripUop.TabIndex = 0;
+            statusStripUop.Text = "statusStripUop";
+            // 
+            // StatusUopText
+            // 
+            StatusUopText.Name = "StatusUopText";
+            StatusUopText.Size = new System.Drawing.Size(0, 17);
+            // 
+            // tabPageUopComponents
+            // 
+            tabPageUopComponents.Controls.Add(UopComponentBox);
+            tabPageUopComponents.Location = new System.Drawing.Point(4, 24);
+            tabPageUopComponents.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            tabPageUopComponents.Name = "tabPageUopComponents";
+            tabPageUopComponents.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            tabPageUopComponents.Size = new System.Drawing.Size(489, 386);
+            tabPageUopComponents.TabIndex = 1;
+            tabPageUopComponents.Text = "Component List";
+            tabPageUopComponents.UseVisualStyleBackColor = true;
+            // 
+            // UopComponentBox
+            // 
+            UopComponentBox.Dock = System.Windows.Forms.DockStyle.Fill;
+            UopComponentBox.Location = new System.Drawing.Point(4, 3);
+            UopComponentBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            UopComponentBox.Name = "UopComponentBox";
+            UopComponentBox.ReadOnly = true;
+            UopComponentBox.Size = new System.Drawing.Size(481, 380);
+            UopComponentBox.TabIndex = 0;
+            UopComponentBox.Text = "";
+            // 
             // MultisControl
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            Controls.Add(splitContainer2);
+            Controls.Add(tabControlSource);
             DoubleBuffered = true;
             Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             Name = "MultisControl";
@@ -560,11 +1068,42 @@ namespace UoFiddler.Controls.UserControls
             splitContainer4.Panel2.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)splitContainer4).EndInit();
             splitContainer4.ResumeLayout(false);
+            panelMultiScroll.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)MultiPictureBox).EndInit();
             contextMenuStrip1.ResumeLayout(false);
             statusMulti.ResumeLayout(false);
             statusMulti.PerformLayout();
             tabPage6.ResumeLayout(false);
+            panelUopScroll.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)UopPictureBox).EndInit();
+            contextMenuStripUopPic.ResumeLayout(false);
+            tabControlSource.ResumeLayout(false);
+            tabPageMul.ResumeLayout(false);
+            tabPageUop.ResumeLayout(false);
+            splitContainerUop.Panel1.ResumeLayout(false);
+            splitContainerUop.Panel1.PerformLayout();
+            splitContainerUop.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)splitContainerUop).EndInit();
+            splitContainerUop.ResumeLayout(false);
+            contextMenuStripUop.ResumeLayout(false);
+            toolStripUop.ResumeLayout(false);
+            toolStripUop.PerformLayout();
+            tabControlUopDetail.ResumeLayout(false);
+            tabPageUopPreview.ResumeLayout(false);
+            splitContainerUop3.Panel1.ResumeLayout(false);
+            splitContainerUop3.Panel1.PerformLayout();
+            splitContainerUop3.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)splitContainerUop3).EndInit();
+            splitContainerUop3.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)HeightChangeUop).EndInit();
+            splitContainerUop4.Panel1.ResumeLayout(false);
+            splitContainerUop4.Panel2.ResumeLayout(false);
+            splitContainerUop4.Panel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)splitContainerUop4).EndInit();
+            splitContainerUop4.ResumeLayout(false);
+            statusStripUop.ResumeLayout(false);
+            statusStripUop.PerformLayout();
+            tabPageUopComponents.ResumeLayout(false);
             ResumeLayout(false);
         }
 
@@ -619,5 +1158,50 @@ namespace UoFiddler.Controls.UserControls
         private System.Windows.Forms.ToolStripMenuItem toUOX3FileToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem toUOX3ToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem toXMLFileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripButton fitModeToolStripMenuItem;
+        private System.Windows.Forms.ToolStripButton uopFitModeToolStripMenuItem;
+        private System.Windows.Forms.ToolStripButton helpToolStripButton;
+        private System.Windows.Forms.ToolStripButton uopHelpToolStripButton;
+        private System.Windows.Forms.Panel panelMultiScroll;
+        private System.Windows.Forms.Panel panelUopScroll;
+        private System.Windows.Forms.TabControl tabControlSource;
+        private System.Windows.Forms.TabPage tabPageMul;
+        private System.Windows.Forms.TabPage tabPageUop;
+        private System.Windows.Forms.SplitContainer splitContainerUop;
+        private System.Windows.Forms.TreeView treeViewUop;
+        private System.Windows.Forms.ContextMenuStrip contextMenuStripUop;
+        private System.Windows.Forms.ToolStripMenuItem uopExportToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem uopToTextfileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem uopToUOAToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem uopToWscToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem uopToCsvToolStripMenuItem;
+        private System.Windows.Forms.ToolStrip toolStripUop;
+        private System.Windows.Forms.ToolStripDropDownButton toolStripDropDownUop;
+        private System.Windows.Forms.ToolStripMenuItem uopExportAllImagesToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem uopAsBmpToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem uopAsTiffToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem uopAsJpgToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem uopAsPngToolStripMenuItem;
+        private System.Windows.Forms.ToolStripSeparator uopToolStripSeparator1;
+        private System.Windows.Forms.ToolStripMenuItem uopExportAllPartsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem uopToUOAFileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem uopToWSCFileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem uopToCSVFileToolStripMenuItem;
+        private System.Windows.Forms.TabControl tabControlUopDetail;
+        private System.Windows.Forms.TabPage tabPageUopPreview;
+        private System.Windows.Forms.SplitContainer splitContainerUop3;
+        private System.Windows.Forms.TrackBar HeightChangeUop;
+        private System.Windows.Forms.SplitContainer splitContainerUop4;
+        private System.Windows.Forms.PictureBox UopPictureBox;
+        private System.Windows.Forms.ContextMenuStrip contextMenuStripUopPic;
+        private System.Windows.Forms.ToolStripMenuItem uopExtractImageToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem uopAsBmpPicToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem uopAsTiffPicToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem uopAsJpgPicToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem uopAsPngPicToolStripMenuItem;
+        private System.Windows.Forms.StatusStrip statusStripUop;
+        private System.Windows.Forms.ToolStripStatusLabel StatusUopText;
+        private System.Windows.Forms.TabPage tabPageUopComponents;
+        private System.Windows.Forms.RichTextBox UopComponentBox;
     }
 }

--- a/UoFiddler.Controls/UserControls/MultisControl.cs
+++ b/UoFiddler.Controls/UserControls/MultisControl.cs
@@ -49,6 +49,18 @@ namespace UoFiddler.Controls.UserControls
         private bool _showFreeSlots;
         private readonly MultisControl _refMarker;
         private bool _useTransparencyForPng = true;
+        private bool _previewFitMode = true;
+        private Bitmap _mulBitmap;
+        private Bitmap _uopBitmap;
+        private bool _isPanning;
+        private Point _panStartScreen;
+        private double _zoomLevel = 1.0;
+        private const double _zoomFactor = 1.25;
+        private const double _zoomMin = 0.25;
+        private const double _zoomMax = 2.0;
+        private string _mulStatusBase = string.Empty;
+        private string _uopStatusBase = string.Empty;
+        private MouseWheelFilter _mouseWheelFilter;
 
         /// <summary>
         /// ReLoads if loaded
@@ -59,6 +71,57 @@ namespace UoFiddler.Controls.UserControls
             {
                 OnLoad(this, EventArgs.Empty);
             }
+        }
+
+        private string BuildNodeLabel(int i)
+        {
+            if (_xmlDocument == null)
+            {
+                return string.Format("{0,5} (0x{0:X})", i);
+            }
+
+            XmlNodeList xMultiNodeList = _xmlElementMultis.SelectNodes("/Multis/Multi[@id='" + i + "']");
+            string name = "";
+            foreach (XmlNode xMultiNode in xMultiNodeList)
+            {
+                name = xMultiNode.Attributes["name"].Value;
+            }
+
+            return $"{i,5} (0x{i:X}) {name}";
+        }
+
+        private TreeNode BuildMulNode(int i, MultiComponentList multi)
+        {
+            TreeNode node;
+            if (_xmlDocument == null)
+            {
+                node = new TreeNode(BuildNodeLabel(i));
+            }
+            else
+            {
+                node = new TreeNode(BuildNodeLabel(i));
+                XmlNodeList xMultiNodeList = _xmlElementMultis.SelectNodes("/Multis/Multi[@id='" + i + "']");
+                string name = "";
+                foreach (XmlNode xMultiNode in xMultiNodeList)
+                {
+                    name = xMultiNode.Attributes["name"].Value;
+                }
+
+                XmlNodeList tooltipList = _xmlElementMultis.SelectNodes("/Multis/ToolTip[@id='" + i + "']");
+                foreach (XmlNode xMultiNode in tooltipList)
+                {
+                    node.ToolTipText = name + "\r\n" + xMultiNode.Attributes["text"].Value;
+                }
+
+                if (tooltipList.Count == 0)
+                {
+                    node.ToolTipText = name;
+                }
+            }
+
+            node.Tag = multi;
+            node.Name = i.ToString();
+            return node;
         }
 
         private void OnLoad(object sender, EventArgs e)
@@ -88,37 +151,7 @@ namespace UoFiddler.Controls.UserControls
                         continue;
                     }
 
-                    TreeNode node;
-                    if (_xmlDocument == null)
-                    {
-                        node = new TreeNode(string.Format("{0,5} (0x{0:X})", i));
-                    }
-                    else
-                    {
-                        XmlNodeList xMultiNodeList = _xmlElementMultis.SelectNodes("/Multis/Multi[@id='" + i + "']");
-                        string j = "";
-
-                        foreach (XmlNode xMultiNode in xMultiNodeList)
-                        {
-                            j = xMultiNode.Attributes["name"].Value;
-                        }
-
-                        node = new TreeNode($"{i,5} (0x{i:X}) {j}");
-                        xMultiNodeList = _xmlElementMultis.SelectNodes("/Multis/ToolTip[@id='" + i + "']");
-                        foreach (XmlNode xMultiNode in xMultiNodeList)
-                        {
-                            node.ToolTipText = j + "\r\n" + xMultiNode.Attributes["text"].Value;
-                        }
-
-                        if (xMultiNodeList.Count == 0)
-                        {
-                            node.ToolTipText = j;
-                        }
-                    }
-
-                    node.Tag = multi;
-                    node.Name = i.ToString();
-                    cache.Add(node);
+                    cache.Add(BuildMulNode(i, multi));
                 }
 
                 TreeViewMulti.Nodes.AddRange(cache.ToArray());
@@ -141,17 +174,22 @@ namespace UoFiddler.Controls.UserControls
             }
 
             _loaded = true;
+
+            LoadUopTree();
+
             Cursor.Current = Cursors.Default;
         }
 
         private void OnFilePathChangeEvent()
         {
+            Multis.ReloadUop();
             Reload();
         }
 
         private void OnPreviewBackgroundColorChanged()
         {
             MultiPictureBox.BackColor = Options.PreviewBackgroundColor;
+            UopPictureBox.BackColor = Options.PreviewBackgroundColor;
         }
 
         private void OnMultiChangeEvent(object sender, int id)
@@ -253,76 +291,104 @@ namespace UoFiddler.Controls.UserControls
             {
                 HeightChangeMulti.Maximum = 0;
                 toolTip.SetToolTip(HeightChangeMulti, "MaxHeight: 0");
-                StatusMultiText.Text = "Size: 0,0 MaxHeight: 0 MultiRegion: 0,0,0,0";
+                SetMulStatus("Size: 0,0 MaxHeight: 0 MultiRegion: 0,0,0,0");
             }
             else
             {
                 HeightChangeMulti.Maximum = multi.MaxHeight;
                 toolTip.SetToolTip(HeightChangeMulti,
                     $"MaxHeight: {HeightChangeMulti.Maximum - HeightChangeMulti.Value}");
-                StatusMultiText.Text =
-                    $"Size: {multi.Width},{multi.Height} MaxHeight: {multi.MaxHeight} MultiRegion: {multi.Min.X},{multi.Min.Y},{multi.Max.X},{multi.Max.Y} Surface: {multi.Surface}";
+                SetMulStatus($"Size: {multi.Width},{multi.Height} MaxHeight: {multi.MaxHeight} MultiRegion: {multi.Min.X},{multi.Min.Y},{multi.Max.X},{multi.Max.Y} Surface: {multi.Surface}");
             }
             ChangeComponentList(multi);
+            RefreshMulBitmap();
+            UpdateMulPictureBox();
+        }
+
+        private void RefreshMulBitmap()
+        {
+            _mulBitmap?.Dispose();
+            _mulBitmap = null;
+            if (TreeViewMulti.SelectedNode?.Tag is MultiComponentList multi && multi != MultiComponentList.Empty)
+            {
+                int h = HeightChangeMulti.Maximum - HeightChangeMulti.Value;
+                _mulBitmap = multi.GetImage(h);
+            }
+        }
+
+        private void UpdateMulPictureBox()
+        {
+            if (_previewFitMode || _mulBitmap == null)
+            {
+                MultiPictureBox.Dock = DockStyle.Fill;
+                MultiPictureBox.Cursor = Cursors.Default;
+            }
+            else
+            {
+                MultiPictureBox.Dock = DockStyle.None;
+                CenterPictureBox(MultiPictureBox, panelMultiScroll, GetZoomedSize(_mulBitmap.Size));
+                MultiPictureBox.Cursor = Cursors.Hand;
+            }
             MultiPictureBox.Invalidate();
         }
 
         private void OnPaint_MultiPic(object sender, PaintEventArgs e)
         {
-            if (TreeViewMulti.SelectedNode == null)
+            if (_mulBitmap == null)
             {
+                e.Graphics.Clear(MultiPictureBox.BackColor);
                 return;
             }
 
-            if ((MultiComponentList)TreeViewMulti.SelectedNode.Tag == MultiComponentList.Empty)
+            if (_previewFitMode)
             {
-                e.Graphics.Clear(Color.White);
-                return;
-            }
-            int h = HeightChangeMulti.Maximum - HeightChangeMulti.Value;
-            Bitmap mMainPictureMulti = ((MultiComponentList)TreeViewMulti.SelectedNode.Tag).GetImage(h);
-            if (mMainPictureMulti == null)
-            {
-                e.Graphics.Clear(Color.White);
-                return;
-            }
-            Point location = Point.Empty;
-            Size size = MultiPictureBox.Size;
-            Rectangle destRect;
-            if (mMainPictureMulti.Height < size.Height && mMainPictureMulti.Width < size.Width)
-            {
-                location.X = (MultiPictureBox.Width - mMainPictureMulti.Width) / 2;
-                location.Y = (MultiPictureBox.Height - mMainPictureMulti.Height) / 2;
-                destRect = new Rectangle(location, mMainPictureMulti.Size);
-            }
-            else if (mMainPictureMulti.Height < size.Height)
-            {
-                location.X = 0;
-                location.Y = (MultiPictureBox.Height - mMainPictureMulti.Height) / 2;
-                destRect = mMainPictureMulti.Width > size.Width
-                    ? new Rectangle(location, new Size(size.Width, mMainPictureMulti.Height))
-                    : new Rectangle(location, mMainPictureMulti.Size);
-            }
-            else if (mMainPictureMulti.Width < size.Width)
-            {
-                location.X = (MultiPictureBox.Width - mMainPictureMulti.Width) / 2;
-                location.Y = 0;
-                destRect = mMainPictureMulti.Height > size.Height
-                    ? new Rectangle(location, new Size(mMainPictureMulti.Width, size.Height))
-                    : new Rectangle(location, mMainPictureMulti.Size);
+                DrawFit(e.Graphics, _mulBitmap, MultiPictureBox.Size);
             }
             else
             {
-                destRect = new Rectangle(new Point(0, 0), size);
+                e.Graphics.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.NearestNeighbor;
+                e.Graphics.PixelOffsetMode = System.Drawing.Drawing2D.PixelOffsetMode.Half;
+                e.Graphics.DrawImage(_mulBitmap, 0, 0, MultiPictureBox.Width, MultiPictureBox.Height);
+            }
+        }
+
+        private static void DrawFit(Graphics g, Bitmap bmp, Size box)
+        {
+            Point location = Point.Empty;
+            Rectangle destRect;
+            if (bmp.Height < box.Height && bmp.Width < box.Width)
+            {
+                location.X = (box.Width - bmp.Width) / 2;
+                location.Y = (box.Height - bmp.Height) / 2;
+                destRect = new Rectangle(location, bmp.Size);
+            }
+            else if (bmp.Height < box.Height)
+            {
+                location.Y = (box.Height - bmp.Height) / 2;
+                destRect = bmp.Width > box.Width
+                    ? new Rectangle(location, new Size(box.Width, bmp.Height))
+                    : new Rectangle(location, bmp.Size);
+            }
+            else if (bmp.Width < box.Width)
+            {
+                location.X = (box.Width - bmp.Width) / 2;
+                destRect = bmp.Height > box.Height
+                    ? new Rectangle(location, new Size(bmp.Width, box.Height))
+                    : new Rectangle(location, bmp.Size);
+            }
+            else
+            {
+                destRect = new Rectangle(Point.Empty, box);
             }
 
-            e.Graphics.DrawImage(mMainPictureMulti, destRect, 0, 0, mMainPictureMulti.Width, mMainPictureMulti.Height, GraphicsUnit.Pixel);
+            g.DrawImage(bmp, destRect, 0, 0, bmp.Width, bmp.Height, GraphicsUnit.Pixel);
         }
 
         private void OnValue_HeightChangeMulti(object sender, EventArgs e)
         {
             toolTip.SetToolTip(HeightChangeMulti, $"MaxHeight: {HeightChangeMulti.Maximum - HeightChangeMulti.Value}");
-            MultiPictureBox.Invalidate();
+            RefreshMulBitmap();
+            UpdateMulPictureBox();
         }
 
         private void ChangeComponentList(MultiComponentList multi)
@@ -371,26 +437,16 @@ namespace UoFiddler.Controls.UserControls
 
         private void ExtractMultiImage(ImageFormat imageFormat, Color backgroundColor)
         {
-            string fileExtension = Utils.GetFileExtensionFor(imageFormat);
-            string floorSuffix = HeightChangeMulti.Value > 0
-                ? $"_Z{HeightChangeMulti.Value:000}"
-                : string.Empty;
-
-            string fileName = Path.Combine(Options.OutputPath, $"Multi 0x{int.Parse(TreeViewMulti.SelectedNode.Name):X4}{floorSuffix}.{fileExtension}");
-
-            int selectedMaxHeight = HeightChangeMulti.Maximum - HeightChangeMulti.Value;
-
-            using (Bitmap multiBitmap = ((MultiComponentList)TreeViewMulti.SelectedNode.Tag)?.GetImage(selectedMaxHeight))
+            if (_mulBitmap == null)
             {
-                if (multiBitmap == null)
-                {
-                    return;
-                }
-
-                SaveImage(multiBitmap, fileName, imageFormat, backgroundColor);
-
-                FileSavedDialog.Show(FindForm(), fileName, "Multi saved successfully.");
+                return;
             }
+
+            string fileExtension = Utils.GetFileExtensionFor(imageFormat);
+            string floorSuffix = HeightChangeMulti.Value > 0 ? $"_Z{HeightChangeMulti.Value:000}" : string.Empty;
+            string fileName = Path.Combine(Options.OutputPath, $"Multi 0x{int.Parse(TreeViewMulti.SelectedNode.Name):X4}{floorSuffix}.{fileExtension}");
+            SaveImage(_mulBitmap, fileName, imageFormat, backgroundColor);
+            FileSavedDialog.Show(FindForm(), fileName, "Multi saved successfully.");
         }
 
         private static void SaveImage(Image sourceImage, string fileName, ImageFormat imageFormat, Color backgroundColor)
@@ -417,23 +473,7 @@ namespace UoFiddler.Controls.UserControls
                 for (int i = 0; i < Multis.MaximumMultiIndex; ++i)
                 {
                     MultiComponentList multi = Multis.GetComponents(i);
-                    TreeNode node;
-                    if (_xmlDocument == null)
-                    {
-                        node = new TreeNode($"{i,5} (0x{i:X})");
-                    }
-                    else
-                    {
-                        XmlNodeList xMultiNodeList = _xmlElementMultis.SelectNodes("/Multis/Multi[@id='" + i + "']");
-                        string j = "";
-                        foreach (XmlNode xMultiNode in xMultiNodeList)
-                        {
-                            j = xMultiNode.Attributes["name"].Value;
-                        }
-                        node = new TreeNode(string.Format("{0,5} (0x{0:X}) {1}", i, j));
-                    }
-                    node.Name = i.ToString();
-                    node.Tag = multi;
+                    TreeNode node = BuildMulNode(i, multi);
                     if (multi == MultiComponentList.Empty)
                     {
                         node.ForeColor = Color.Red;
@@ -452,24 +492,7 @@ namespace UoFiddler.Controls.UserControls
                         continue;
                     }
 
-                    TreeNode node;
-                    if (_xmlDocument == null)
-                    {
-                        node = new TreeNode($"{i,5} (0x{i:X})");
-                    }
-                    else
-                    {
-                        XmlNodeList xMultiNodeList = _xmlElementMultis.SelectNodes("/Multis/Multi[@id='" + i + "']");
-                        string j = "";
-                        foreach (XmlNode xMultiNode in xMultiNodeList)
-                        {
-                            j = xMultiNode.Attributes["name"].Value;
-                        }
-                        node = new TreeNode(string.Format("{0,5} (0x{0:X}) {1}", i, j));
-                    }
-                    node.Tag = multi;
-                    node.Name = i.ToString();
-                    TreeViewMulti.Nodes.Add(node);
+                    TreeViewMulti.Nodes.Add(BuildMulNode(i, multi));
                 }
             }
             TreeViewMulti.EndUpdate();
@@ -590,8 +613,9 @@ namespace UoFiddler.Controls.UserControls
                 }
             }
 
-            using (var dialog = new MultiImportForm(id, ChangeMulti) { TopMost = true })
+            using (var dialog = new MultiImportForm(id, ChangeMulti))
             {
+                dialog.TopMost = true;
                 dialog.ShowDialog();
             }
         }
@@ -879,6 +903,580 @@ namespace UoFiddler.Controls.UserControls
             _useTransparencyForPng = UseTransparencyForPNGToolStripMenuItem.Checked;
         }
 
+        private void LoadUopTree()
+        {
+            treeViewUop.BeginUpdate();
+            treeViewUop.Nodes.Clear();
+
+            if (!Multis.HasUopFile)
+            {
+                treeViewUop.Nodes.Add(new TreeNode("multicollection.uop not found or path is not set.") { Name = "-1" });
+                treeViewUop.EndUpdate();
+                return;
+            }
+
+            var cache = new List<TreeNode>();
+            for (int i = 0; i < Multis.MaximumMultiIndex; ++i)
+            {
+                MultiComponentList multi = Multis.GetUopComponents(i);
+                if (multi == MultiComponentList.Empty)
+                {
+                    continue;
+                }
+
+                cache.Add(new TreeNode(BuildNodeLabel(i)) { Tag = multi, Name = i.ToString() });
+            }
+
+            treeViewUop.Nodes.AddRange(cache.ToArray());
+            treeViewUop.EndUpdate();
+
+            if (treeViewUop.Nodes.Count > 0)
+            {
+                treeViewUop.SelectedNode = treeViewUop.Nodes[0];
+            }
+        }
+
+        private void AfterSelect_UopMulti(object sender, TreeViewEventArgs e)
+        {
+            if (treeViewUop.SelectedNode?.Tag is not MultiComponentList multi)
+            {
+                return;
+            }
+
+            if (multi == MultiComponentList.Empty)
+            {
+                HeightChangeUop.Maximum = 0;
+                toolTip.SetToolTip(HeightChangeUop, "MaxHeight: 0");
+                SetUopStatus("Size: 0,0 MaxHeight: 0 MultiRegion: 0,0,0,0");
+            }
+            else
+            {
+                HeightChangeUop.Maximum = multi.MaxHeight;
+                toolTip.SetToolTip(HeightChangeUop, $"MaxHeight: {HeightChangeUop.Maximum - HeightChangeUop.Value}");
+                SetUopStatus($"Size: {multi.Width},{multi.Height} MaxHeight: {multi.MaxHeight} MultiRegion: {multi.Min.X},{multi.Min.Y},{multi.Max.X},{multi.Max.Y} Surface: {multi.Surface}");
+            }
+
+            ChangeUopComponentList(multi);
+            RefreshUopBitmap();
+            UpdateUopPictureBox();
+        }
+
+        private void RefreshUopBitmap()
+        {
+            _uopBitmap?.Dispose();
+            _uopBitmap = null;
+            if (treeViewUop.SelectedNode?.Tag is MultiComponentList multi && multi != MultiComponentList.Empty)
+            {
+                int h = HeightChangeUop.Maximum - HeightChangeUop.Value;
+                _uopBitmap = multi.GetImage(h);
+            }
+        }
+
+        private void UpdateUopPictureBox()
+        {
+            if (_previewFitMode || _uopBitmap == null)
+            {
+                UopPictureBox.Dock = DockStyle.Fill;
+                UopPictureBox.Cursor = Cursors.Default;
+            }
+            else
+            {
+                UopPictureBox.Dock = DockStyle.None;
+                CenterPictureBox(UopPictureBox, panelUopScroll, GetZoomedSize(_uopBitmap.Size));
+                UopPictureBox.Cursor = Cursors.Hand;
+            }
+            UopPictureBox.Invalidate();
+        }
+
+        private void ChangeUopComponentList(MultiComponentList multi)
+        {
+            UopComponentBox.Clear();
+            if (multi == MultiComponentList.Empty)
+            {
+                return;
+            }
+
+            bool isUohsa = Art.IsUOAHS();
+            for (int x = 0; x < multi.Width; ++x)
+            {
+                for (int y = 0; y < multi.Height; ++y)
+                {
+                    foreach (var mTile in multi.Tiles[x][y])
+                    {
+                        UopComponentBox.AppendText(
+                            isUohsa
+                                ? $"0x{mTile.Id:X4} {x,3} {y,3} {mTile.Z,2} {mTile.Flag,2} {mTile.Unk1,2}\n"
+                                : $"0x{mTile.Id:X4} {x,3} {y,3} {mTile.Z,2} {mTile.Flag,2}\n");
+                    }
+                }
+            }
+        }
+
+        private void OnValue_HeightChangeUop(object sender, EventArgs e)
+        {
+            toolTip.SetToolTip(HeightChangeUop, $"MaxHeight: {HeightChangeUop.Maximum - HeightChangeUop.Value}");
+            RefreshUopBitmap();
+            UpdateUopPictureBox();
+        }
+
+        private void OnPaint_UopMultiPic(object sender, PaintEventArgs e)
+        {
+            if (_uopBitmap == null)
+            {
+                e.Graphics.Clear(UopPictureBox.BackColor);
+                return;
+            }
+
+            if (_previewFitMode)
+            {
+                DrawFit(e.Graphics, _uopBitmap, UopPictureBox.Size);
+            }
+            else
+            {
+                e.Graphics.InterpolationMode = System.Drawing.Drawing2D.InterpolationMode.NearestNeighbor;
+                e.Graphics.PixelOffsetMode = System.Drawing.Drawing2D.PixelOffsetMode.Half;
+                e.Graphics.DrawImage(_uopBitmap, 0, 0, UopPictureBox.Width, UopPictureBox.Height);
+            }
+        }
+
+        private void OnToggleFitMode(object sender, EventArgs e)
+        {
+            _previewFitMode = ((System.Windows.Forms.ToolStripButton)sender).Checked;
+            fitModeToolStripMenuItem.CheckedChanged -= OnToggleFitMode;
+            uopFitModeToolStripMenuItem.CheckedChanged -= OnToggleFitMode;
+            fitModeToolStripMenuItem.Checked = _previewFitMode;
+            uopFitModeToolStripMenuItem.Checked = _previewFitMode;
+            fitModeToolStripMenuItem.CheckedChanged += OnToggleFitMode;
+            uopFitModeToolStripMenuItem.CheckedChanged += OnToggleFitMode;
+            UpdateMulPictureBox();
+            UpdateUopPictureBox();
+            UpdateZoomStatus();
+        }
+
+        private static void CenterPictureBox(PictureBox pic, Panel panel, Size bitmapSize)
+        {
+            // Set size first so the panel can clamp AutoScrollPosition to the new valid range.
+            pic.Size = bitmapSize;
+
+            int vx = Math.Max(0, (panel.ClientSize.Width - bitmapSize.Width) / 2);
+            int vy = Math.Max(0, (panel.ClientSize.Height - bitmapSize.Height) / 2);
+
+            // AutoScrollPosition getter returns a negative offset (e.g. (0,-100) when scrolled 100 down).
+            // Control.Location in a scrolled Panel is relative to the current view, not the virtual origin,
+            // so we add the scroll offset to land at the correct virtual position.
+            Point scroll = panel.AutoScrollPosition;
+            pic.Location = new Point(vx + scroll.X, vy + scroll.Y);
+        }
+
+        private void OnPanelMultiScroll_Resize(object sender, EventArgs e)
+        {
+            if (!_previewFitMode && _mulBitmap != null)
+            {
+                CenterPictureBox(MultiPictureBox, panelMultiScroll, GetZoomedSize(_mulBitmap.Size));
+            }
+        }
+
+        private void OnPanelUopScroll_Resize(object sender, EventArgs e)
+        {
+            if (!_previewFitMode && _uopBitmap != null)
+            {
+                CenterPictureBox(UopPictureBox, panelUopScroll, GetZoomedSize(_uopBitmap.Size));
+            }
+        }
+
+        private void OnMulPan_MouseDown(object sender, MouseEventArgs e)
+        {
+            if (_previewFitMode || e.Button != MouseButtons.Left)
+            {
+                return;
+            }
+
+            _isPanning = true;
+            _panStartScreen = Cursor.Position;
+            MultiPictureBox.Cursor = Cursors.SizeAll;
+        }
+
+        private void OnMulPan_MouseMove(object sender, MouseEventArgs e)
+        {
+            if (!_isPanning)
+            {
+                return;
+            }
+
+            PanPanel(panelMultiScroll);
+        }
+
+        private void OnUopPan_MouseDown(object sender, MouseEventArgs e)
+        {
+            if (_previewFitMode || e.Button != MouseButtons.Left)
+            {
+                return;
+            }
+
+            _isPanning = true;
+            _panStartScreen = Cursor.Position;
+            UopPictureBox.Cursor = Cursors.SizeAll;
+        }
+
+        private void OnUopPan_MouseMove(object sender, MouseEventArgs e)
+        {
+            if (!_isPanning)
+            {
+                return;
+            }
+
+            PanPanel(panelUopScroll);
+        }
+
+        private void OnPan_MouseUp(object sender, MouseEventArgs e)
+        {
+            if (!_isPanning)
+            {
+                return;
+            }
+
+            _isPanning = false;
+            ((Control)sender).Cursor = _previewFitMode ? Cursors.Default : Cursors.Hand;
+        }
+
+        private void PanPanel(Panel panel)
+        {
+            Point pos = Cursor.Position;
+            int dx = pos.X - _panStartScreen.X;
+            int dy = pos.Y - _panStartScreen.Y;
+            Point scroll = panel.AutoScrollPosition;
+            panel.AutoScrollPosition = new Point(
+                Math.Max(0, -scroll.X - dx),
+                Math.Max(0, -scroll.Y - dy)
+            );
+            _panStartScreen = pos;
+        }
+
+        private Size GetZoomedSize(Size bitmapSize) =>
+            new Size(Math.Max(1, (int)(bitmapSize.Width * _zoomLevel)),
+                     Math.Max(1, (int)(bitmapSize.Height * _zoomLevel)));
+
+        private void ZoomIn() => SetZoom(_zoomLevel * _zoomFactor);
+        private void ZoomOut() => SetZoom(_zoomLevel / _zoomFactor);
+        private void ZoomReset() => SetZoom(1.0);
+
+        private void SetZoom(double zoom)
+        {
+            _zoomLevel = Math.Clamp(zoom, _zoomMin, _zoomMax);
+            if (_previewFitMode)
+            {
+                return;
+            }
+
+            UpdateMulPictureBox();
+            UpdateUopPictureBox();
+            UpdateZoomStatus();
+        }
+
+        private void UpdateZoomStatus()
+        {
+            SetMulStatus(_mulStatusBase);
+            SetUopStatus(_uopStatusBase);
+        }
+
+        private void SetMulStatus(string baseText)
+        {
+            _mulStatusBase = baseText;
+            StatusMultiText.Text = _previewFitMode
+                ? baseText
+                : $"{baseText}  Zoom: {_zoomLevel * 100:F0}%";
+        }
+
+        private void SetUopStatus(string baseText)
+        {
+            _uopStatusBase = baseText;
+            StatusUopText.Text = _previewFitMode
+                ? baseText
+                : $"{baseText}  Zoom: {_zoomLevel * 100:F0}%";
+        }
+
+        protected override void OnHandleCreated(EventArgs e)
+        {
+            base.OnHandleCreated(e);
+            _mouseWheelFilter = new MouseWheelFilter(this);
+            Application.AddMessageFilter(_mouseWheelFilter);
+        }
+
+        protected override void OnHandleDestroyed(EventArgs e)
+        {
+            if (_mouseWheelFilter != null)
+            {
+                Application.RemoveMessageFilter(_mouseWheelFilter);
+            }
+
+            base.OnHandleDestroyed(e);
+        }
+
+        protected override bool ProcessCmdKey(ref Message msg, Keys keyData)
+        {
+            if (_previewFitMode)
+            {
+                return base.ProcessCmdKey(ref msg, keyData);
+            }
+
+            switch (keyData)
+            {
+                case Keys.Oemplus | Keys.Shift:
+                case Keys.Add:
+                    ZoomIn();
+                    return true;
+                case Keys.OemMinus:
+                case Keys.Subtract:
+                    ZoomOut();
+                    return true;
+                case Keys.D0 | Keys.Control:
+                case Keys.NumPad0 | Keys.Control:
+                    ZoomReset();
+                    return true;
+                default:
+                    return base.ProcessCmdKey(ref msg, keyData);
+            }
+        }
+
+        private void OnClickHelp(object sender, EventArgs e)
+        {
+            using var form = new MultisHelpForm();
+            form.ShowDialog(this);
+        }
+
+        private void UopExtract_Image_ClickBmp(object sender, EventArgs e) =>
+            ExtractUopMultiImage(ImageFormat.Bmp, Options.PreviewBackgroundColor);
+
+        private void UopExtract_Image_ClickTiff(object sender, EventArgs e) =>
+            ExtractUopMultiImage(ImageFormat.Tiff, Options.PreviewBackgroundColor);
+
+        private void UopExtract_Image_ClickJpg(object sender, EventArgs e) =>
+            ExtractUopMultiImage(ImageFormat.Jpeg, Options.PreviewBackgroundColor);
+
+        private void UopExtract_Image_ClickPng(object sender, EventArgs e) =>
+            ExtractUopMultiImage(ImageFormat.Png, _useTransparencyForPng ? Color.Transparent : Options.PreviewBackgroundColor);
+
+        private void ExtractUopMultiImage(ImageFormat imageFormat, Color backgroundColor)
+        {
+            if (_uopBitmap == null)
+            {
+                return;
+            }
+
+            string fileExtension = Utils.GetFileExtensionFor(imageFormat);
+            string floorSuffix = HeightChangeUop.Value > 0 ? $"_Z{HeightChangeUop.Value:000}" : string.Empty;
+            int id = int.Parse(treeViewUop.SelectedNode.Name);
+            string fileName = Path.Combine(Options.OutputPath, $"UopMulti 0x{id:X4}{floorSuffix}.{fileExtension}");
+            SaveImage(_uopBitmap, fileName, imageFormat, backgroundColor);
+            FileSavedDialog.Show(FindForm(), fileName, "Multi saved successfully.");
+        }
+
+        private void OnUopExportTextFile(object sender, EventArgs e)
+        {
+            if (treeViewUop.SelectedNode?.Tag is not MultiComponentList multi || multi == MultiComponentList.Empty)
+            {
+                return;
+            }
+
+            int id = int.Parse(treeViewUop.SelectedNode.Name);
+            string fileName = Path.Combine(Options.OutputPath, $"UopMulti 0x{id:X}.txt");
+            multi.ExportToTextFile(fileName);
+            FileSavedDialog.Show(FindForm(), fileName, "Multi saved successfully.");
+        }
+
+        private void OnUopExportUOAFile(object sender, EventArgs e)
+        {
+            if (treeViewUop.SelectedNode?.Tag is not MultiComponentList multi || multi == MultiComponentList.Empty)
+            {
+                return;
+            }
+
+            int id = int.Parse(treeViewUop.SelectedNode.Name);
+            string fileName = Path.Combine(Options.OutputPath, $"UopMulti 0x{id:X}.uoa");
+            multi.ExportToUOAFile(fileName);
+            FileSavedDialog.Show(FindForm(), fileName, "Multi saved successfully.");
+        }
+
+        private void OnUopExportWscFile(object sender, EventArgs e)
+        {
+            if (treeViewUop.SelectedNode?.Tag is not MultiComponentList multi || multi == MultiComponentList.Empty)
+            {
+                return;
+            }
+
+            int id = int.Parse(treeViewUop.SelectedNode.Name);
+            string fileName = Path.Combine(Options.OutputPath, $"UopMulti 0x{id:X}.wsc");
+            multi.ExportToWscFile(fileName);
+            FileSavedDialog.Show(FindForm(), fileName, "Multi saved successfully.");
+        }
+
+        private void OnUopExportCsvFile(object sender, EventArgs e)
+        {
+            if (treeViewUop.SelectedNode?.Tag is not MultiComponentList multi || multi == MultiComponentList.Empty)
+            {
+                return;
+            }
+
+            int id = int.Parse(treeViewUop.SelectedNode.Name);
+            string fileName = Path.Combine(Options.OutputPath, $"{id:D4}_uop.csv");
+            multi.ExportToCsvFile(fileName);
+            FileSavedDialog.Show(FindForm(), fileName, "Multi saved successfully.");
+        }
+
+        private void OnUopClick_SaveAllBmp(object sender, EventArgs e) =>
+            ExportAllUopMultis(ImageFormat.Bmp, Options.PreviewBackgroundColor);
+
+        private void OnUopClick_SaveAllTiff(object sender, EventArgs e) =>
+            ExportAllUopMultis(ImageFormat.Tiff, Options.PreviewBackgroundColor);
+
+        private void OnUopClick_SaveAllJpg(object sender, EventArgs e) =>
+            ExportAllUopMultis(ImageFormat.Jpeg, Options.PreviewBackgroundColor);
+
+        private void OnUopClick_SaveAllPng(object sender, EventArgs e) =>
+            ExportAllUopMultis(ImageFormat.Png, _useTransparencyForPng ? Color.Transparent : Options.PreviewBackgroundColor);
+
+        private void ExportAllUopMultis(ImageFormat imageFormat, Color backgroundColor)
+        {
+            string fileExtension = Utils.GetFileExtensionFor(imageFormat);
+            using var dialog = new FolderBrowserDialog { Description = "Select directory", ShowNewFolderButton = true };
+            if (dialog.ShowDialog() != DialogResult.OK)
+            {
+                return;
+            }
+
+            const int maxHeight = 127;
+            for (int i = 0; i < treeViewUop.Nodes.Count; i++)
+            {
+                if (!int.TryParse(treeViewUop.Nodes[i].Name, out int index) || index < 0)
+                {
+                    continue;
+                }
+
+                if (treeViewUop.Nodes[i].Tag is not MultiComponentList multi || multi == MultiComponentList.Empty)
+                {
+                    continue;
+                }
+
+                string fileName = Path.Combine(dialog.SelectedPath, $"UopMulti 0x{index:X4}.{fileExtension}");
+                using Bitmap bitmap = multi.GetImage(maxHeight);
+                if (bitmap != null)
+                {
+                    SaveImage(bitmap, fileName, imageFormat, backgroundColor);
+                }
+            }
+
+            MessageBox.Show($"All UOP Multis saved to {dialog.SelectedPath}", "Saved", MessageBoxButtons.OK,
+                MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);
+        }
+
+        private void OnUopClick_SaveAllText(object sender, EventArgs e)
+        {
+            using var dialog = new FolderBrowserDialog { Description = "Select directory", ShowNewFolderButton = true };
+            if (dialog.ShowDialog() != DialogResult.OK)
+            {
+                return;
+            }
+
+            for (int i = 0; i < treeViewUop.Nodes.Count; ++i)
+            {
+                if (!int.TryParse(treeViewUop.Nodes[i].Name, out int index) || index < 0)
+                {
+                    continue;
+                }
+
+                if (treeViewUop.Nodes[i].Tag is not MultiComponentList multi || multi == MultiComponentList.Empty)
+                {
+                    continue;
+                }
+
+                multi.ExportToTextFile(Path.Combine(dialog.SelectedPath, $"UopMulti 0x{index:X4}.txt"));
+            }
+
+            MessageBox.Show($"All UOP Multis saved to {dialog.SelectedPath}", "Saved", MessageBoxButtons.OK,
+                MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);
+        }
+
+        private void OnUopClick_SaveAllUOA(object sender, EventArgs e)
+        {
+            using var dialog = new FolderBrowserDialog { Description = "Select directory", ShowNewFolderButton = true };
+            if (dialog.ShowDialog() != DialogResult.OK)
+            {
+                return;
+            }
+
+            for (int i = 0; i < treeViewUop.Nodes.Count; ++i)
+            {
+                if (!int.TryParse(treeViewUop.Nodes[i].Name, out int index) || index < 0)
+                {
+                    continue;
+                }
+
+                if (treeViewUop.Nodes[i].Tag is not MultiComponentList multi || multi == MultiComponentList.Empty)
+                {
+                    continue;
+                }
+
+                multi.ExportToUOAFile(Path.Combine(dialog.SelectedPath, $"UopMulti 0x{index:X4}.uoa"));
+            }
+
+            MessageBox.Show($"All UOP Multis saved to {dialog.SelectedPath}", "Saved", MessageBoxButtons.OK,
+                MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);
+        }
+
+        private void OnUopClick_SaveAllWSC(object sender, EventArgs e)
+        {
+            using var dialog = new FolderBrowserDialog { Description = "Select directory", ShowNewFolderButton = true };
+            if (dialog.ShowDialog() != DialogResult.OK)
+            {
+                return;
+            }
+
+            for (int i = 0; i < treeViewUop.Nodes.Count; ++i)
+            {
+                if (!int.TryParse(treeViewUop.Nodes[i].Name, out int index) || index < 0)
+                {
+                    continue;
+                }
+
+                if (treeViewUop.Nodes[i].Tag is not MultiComponentList multi || multi == MultiComponentList.Empty)
+                {
+                    continue;
+                }
+
+                multi.ExportToWscFile(Path.Combine(dialog.SelectedPath, $"UopMulti 0x{index:X4}.wsc"));
+            }
+
+            MessageBox.Show($"All UOP Multis saved to {dialog.SelectedPath}", "Saved", MessageBoxButtons.OK,
+                MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);
+        }
+
+        private void OnUopClick_SaveAllCSV(object sender, EventArgs e)
+        {
+            using var dialog = new FolderBrowserDialog { Description = "Select directory", ShowNewFolderButton = true };
+            if (dialog.ShowDialog() != DialogResult.OK)
+            {
+                return;
+            }
+
+            for (int i = 0; i < treeViewUop.Nodes.Count; ++i)
+            {
+                if (!int.TryParse(treeViewUop.Nodes[i].Name, out int index) || index < 0)
+                {
+                    continue;
+                }
+
+                if (treeViewUop.Nodes[i].Tag is not MultiComponentList multi || multi == MultiComponentList.Empty)
+                {
+                    continue;
+                }
+
+                multi.ExportToCsvFile(Path.Combine(dialog.SelectedPath, $"{index:D4}_uop.csv"));
+            }
+
+            MessageBox.Show($"All UOP Multis saved to {dialog.SelectedPath}", "Saved", MessageBoxButtons.OK,
+                MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);
+        }
+
         private void OnClick_SaveAllToXML(object sender, EventArgs e)
         {
             string path = Options.OutputPath;
@@ -949,6 +1547,54 @@ namespace UoFiddler.Controls.UserControls
 
             MessageBox.Show($"All Multis saved to {fileName}", "Saved", MessageBoxButtons.OK,
                 MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);
+        }
+
+        private sealed class MouseWheelFilter : IMessageFilter
+        {
+            private const int WmMouseWheel = 0x020A;
+            private readonly MultisControl _owner;
+
+            public MouseWheelFilter(MultisControl owner) => _owner = owner;
+
+            public bool PreFilterMessage(ref Message m)
+            {
+                if (m.Msg != WmMouseWheel)
+                {
+                    return false;
+                }
+
+                if ((Control.ModifierKeys & Keys.Control) == 0)
+                {
+                    return false;
+                }
+
+                Point cursor = Cursor.Position;
+                if (IsOver(_owner.panelMultiScroll, cursor) || IsOver(_owner.panelUopScroll, cursor))
+                {
+                    int delta = (short)((int)m.WParam >> 16);
+                    if (delta > 0)
+                    {
+                        _owner.ZoomIn();
+                    }
+                    else
+                    {
+                        _owner.ZoomOut();
+                    }
+
+                    return true;
+                }
+                return false;
+            }
+
+            private static bool IsOver(Control c, Point screenPt)
+            {
+                if (!c.IsHandleCreated)
+                {
+                    return false;
+                }
+
+                return new Rectangle(c.PointToScreen(Point.Empty), c.Size).Contains(screenPt);
+            }
         }
     }
 }

--- a/UoFiddler.Plugin.Compare/UserControls/CompareCliLocControl.Designer.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareCliLocControl.Designer.cs
@@ -41,8 +41,6 @@ namespace UoFiddler.Plugin.Compare.UserControls
         {
             splitContainer1 = new System.Windows.Forms.SplitContainer();
             dataGridView1 = new System.Windows.Forms.DataGridView();
-            decompressFileTwoCheckBox = new System.Windows.Forms.CheckBox();
-            decompressFileOneCheckBox = new System.Windows.Forms.CheckBox();
             button5 = new System.Windows.Forms.Button();
             checkBox1 = new System.Windows.Forms.CheckBox();
             button4 = new System.Windows.Forms.Button();
@@ -74,8 +72,6 @@ namespace UoFiddler.Plugin.Compare.UserControls
             // 
             // splitContainer1.Panel2
             // 
-            splitContainer1.Panel2.Controls.Add(decompressFileTwoCheckBox);
-            splitContainer1.Panel2.Controls.Add(decompressFileOneCheckBox);
             splitContainer1.Panel2.Controls.Add(button5);
             splitContainer1.Panel2.Controls.Add(checkBox1);
             splitContainer1.Panel2.Controls.Add(button4);
@@ -108,31 +104,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
             dataGridView1.TabIndex = 0;
             dataGridView1.CellFormatting += CellFormatting;
             dataGridView1.ColumnHeaderMouseClick += OnHeaderClicked;
-            // 
-            // decompressFileTwoCheckBox
-            // 
-            decompressFileTwoCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
-            decompressFileTwoCheckBox.AutoSize = true;
-            decompressFileTwoCheckBox.Location = new System.Drawing.Point(399, 39);
-            decompressFileTwoCheckBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            decompressFileTwoCheckBox.Name = "decompressFileTwoCheckBox";
-            decompressFileTwoCheckBox.Size = new System.Drawing.Size(202, 19);
-            decompressFileTwoCheckBox.TabIndex = 9;
-            decompressFileTwoCheckBox.Text = "Decompress cliloc before reading";
-            decompressFileTwoCheckBox.UseVisualStyleBackColor = true;
-            // 
-            // decompressFileOneCheckBox
-            // 
-            decompressFileOneCheckBox.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
-            decompressFileOneCheckBox.AutoSize = true;
-            decompressFileOneCheckBox.Location = new System.Drawing.Point(5, 39);
-            decompressFileOneCheckBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            decompressFileOneCheckBox.Name = "decompressFileOneCheckBox";
-            decompressFileOneCheckBox.Size = new System.Drawing.Size(202, 19);
-            decompressFileOneCheckBox.TabIndex = 8;
-            decompressFileOneCheckBox.Text = "Decompress cliloc before reading";
-            decompressFileOneCheckBox.UseVisualStyleBackColor = true;
-            // 
+            //
             // button5
             // 
             button5.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
@@ -264,7 +236,5 @@ namespace UoFiddler.Plugin.Compare.UserControls
         private System.Windows.Forms.SplitContainer splitContainer1;
         private System.Windows.Forms.TextBox textBox1;
         private System.Windows.Forms.TextBox textBox2;
-        private System.Windows.Forms.CheckBox decompressFileTwoCheckBox;
-        private System.Windows.Forms.CheckBox decompressFileOneCheckBox;
     }
 }

--- a/UoFiddler.Plugin.Compare/UserControls/CompareCliLocControl.Designer.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareCliLocControl.Designer.cs
@@ -1,9 +1,9 @@
-﻿/***************************************************************************
+/***************************************************************************
  *
  * $Author: Turley
- * 
+ *
  * "THE BEER-WARE LICENSE"
- * As long as you retain this notice you can do whatever you want with 
+ * As long as you retain this notice you can do whatever you want with
  * this stuff. If we meet some day, and you think this stuff is worth it,
  * you can buy me a beer in return.
  *
@@ -13,12 +13,12 @@ namespace UoFiddler.Plugin.Compare.UserControls
 {
     partial class CompareCliLocControl
     {
-        /// <summary> 
+        /// <summary>
         /// Required designer variable.
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
-        /// <summary> 
+        /// <summary>
         /// Clean up any resources being used.
         /// </summary>
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
@@ -39,8 +39,9 @@ namespace UoFiddler.Plugin.Compare.UserControls
         /// </summary>
         private void InitializeComponent()
         {
-            splitContainer1 = new System.Windows.Forms.SplitContainer();
+            splitContainerMain = new System.Windows.Forms.SplitContainer();
             dataGridView1 = new System.Windows.Forms.DataGridView();
+            toolbarPanel = new System.Windows.Forms.Panel();
             button5 = new System.Windows.Forms.Button();
             checkBox1 = new System.Windows.Forms.CheckBox();
             button4 = new System.Windows.Forms.Button();
@@ -49,44 +50,47 @@ namespace UoFiddler.Plugin.Compare.UserControls
             button1 = new System.Windows.Forms.Button();
             textBox2 = new System.Windows.Forms.TextBox();
             textBox1 = new System.Windows.Forms.TextBox();
-            ((System.ComponentModel.ISupportInitialize)splitContainer1).BeginInit();
-            splitContainer1.Panel1.SuspendLayout();
-            splitContainer1.Panel2.SuspendLayout();
-            splitContainer1.SuspendLayout();
+            splitContainerDiff = new System.Windows.Forms.SplitContainer();
+            diffRichTextBox1 = new System.Windows.Forms.RichTextBox();
+            labelDiff1 = new System.Windows.Forms.Label();
+            diffRichTextBox2 = new System.Windows.Forms.RichTextBox();
+            labelDiff2 = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)splitContainerMain).BeginInit();
+            splitContainerMain.Panel1.SuspendLayout();
+            splitContainerMain.Panel2.SuspendLayout();
+            splitContainerMain.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)dataGridView1).BeginInit();
+            toolbarPanel.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)splitContainerDiff).BeginInit();
+            splitContainerDiff.Panel1.SuspendLayout();
+            splitContainerDiff.Panel2.SuspendLayout();
+            splitContainerDiff.SuspendLayout();
             SuspendLayout();
-            // 
-            // splitContainer1
-            // 
-            splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
-            splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
-            splitContainer1.IsSplitterFixed = true;
-            splitContainer1.Location = new System.Drawing.Point(0, 0);
-            splitContainer1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            splitContainer1.Name = "splitContainer1";
-            splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            // 
-            // splitContainer1.Panel1
-            // 
-            splitContainer1.Panel1.Controls.Add(dataGridView1);
-            // 
-            // splitContainer1.Panel2
-            // 
-            splitContainer1.Panel2.Controls.Add(button5);
-            splitContainer1.Panel2.Controls.Add(checkBox1);
-            splitContainer1.Panel2.Controls.Add(button4);
-            splitContainer1.Panel2.Controls.Add(button3);
-            splitContainer1.Panel2.Controls.Add(button2);
-            splitContainer1.Panel2.Controls.Add(button1);
-            splitContainer1.Panel2.Controls.Add(textBox2);
-            splitContainer1.Panel2.Controls.Add(textBox1);
-            splitContainer1.Size = new System.Drawing.Size(729, 377);
-            splitContainer1.SplitterDistance = 278;
-            splitContainer1.SplitterWidth = 5;
-            splitContainer1.TabIndex = 0;
-            // 
+            //
+            // splitContainerMain
+            //
+            splitContainerMain.Dock = System.Windows.Forms.DockStyle.Fill;
+            splitContainerMain.Location = new System.Drawing.Point(0, 0);
+            splitContainerMain.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            splitContainerMain.Name = "splitContainerMain";
+            splitContainerMain.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            //
+            // splitContainerMain.Panel1 — dataGrid fills top, toolbar docks to bottom
+            //
+            splitContainerMain.Panel1.Controls.Add(dataGridView1);
+            splitContainerMain.Panel1.Controls.Add(toolbarPanel);
+            //
+            // splitContainerMain.Panel2 — diff detail
+            //
+            splitContainerMain.Panel2.Controls.Add(splitContainerDiff);
+            splitContainerMain.Panel2MinSize = 80;
+            splitContainerMain.Size = new System.Drawing.Size(729, 500);
+            splitContainerMain.SplitterDistance = 377;
+            splitContainerMain.SplitterWidth = 5;
+            splitContainerMain.TabIndex = 0;
+            //
             // dataGridView1
-            // 
+            //
             dataGridView1.AllowUserToAddRows = false;
             dataGridView1.AllowUserToDeleteRows = false;
             dataGridView1.AllowUserToOrderColumns = true;
@@ -100,14 +104,30 @@ namespace UoFiddler.Plugin.Compare.UserControls
             dataGridView1.ReadOnly = true;
             dataGridView1.RowHeadersVisible = false;
             dataGridView1.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
-            dataGridView1.Size = new System.Drawing.Size(729, 278);
+            dataGridView1.Size = new System.Drawing.Size(729, 282);
             dataGridView1.TabIndex = 0;
             dataGridView1.CellFormatting += CellFormatting;
             dataGridView1.ColumnHeaderMouseClick += OnHeaderClicked;
+            dataGridView1.SelectionChanged += OnSelectionChanged;
+            //
+            // toolbarPanel
+            //
+            toolbarPanel.Controls.Add(button5);
+            toolbarPanel.Controls.Add(checkBox1);
+            toolbarPanel.Controls.Add(button4);
+            toolbarPanel.Controls.Add(button3);
+            toolbarPanel.Controls.Add(button2);
+            toolbarPanel.Controls.Add(button1);
+            toolbarPanel.Controls.Add(textBox2);
+            toolbarPanel.Controls.Add(textBox1);
+            toolbarPanel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            toolbarPanel.Height = 95;
+            toolbarPanel.Margin = new System.Windows.Forms.Padding(0);
+            toolbarPanel.Name = "toolbarPanel";
+            toolbarPanel.TabIndex = 1;
             //
             // button5
-            // 
-            button5.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            //
             button5.AutoSize = true;
             button5.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             button5.Location = new System.Drawing.Point(399, 7);
@@ -118,10 +138,9 @@ namespace UoFiddler.Plugin.Compare.UserControls
             button5.Text = "Find Next Diff";
             button5.UseVisualStyleBackColor = true;
             button5.Click += OnClickFindNextDiff;
-            // 
+            //
             // checkBox1
-            // 
-            checkBox1.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            //
             checkBox1.AutoSize = true;
             checkBox1.Location = new System.Drawing.Point(236, 11);
             checkBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
@@ -131,10 +150,10 @@ namespace UoFiddler.Plugin.Compare.UserControls
             checkBox1.Text = "Show Only Differences";
             checkBox1.UseVisualStyleBackColor = true;
             checkBox1.Click += OnClickShowOnlyDiff;
-            // 
+            //
             // button4
-            // 
-            button4.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            //
+            button4.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
             button4.AutoSize = true;
             button4.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             button4.Location = new System.Drawing.Point(647, 63);
@@ -145,10 +164,10 @@ namespace UoFiddler.Plugin.Compare.UserControls
             button4.Text = "..";
             button4.UseVisualStyleBackColor = true;
             button4.Click += OnClickDirFile2;
-            // 
+            //
             // button3
-            // 
-            button3.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            //
+            button3.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left;
             button3.AutoSize = true;
             button3.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             button3.Location = new System.Drawing.Point(236, 63);
@@ -159,10 +178,10 @@ namespace UoFiddler.Plugin.Compare.UserControls
             button3.Text = "..";
             button3.UseVisualStyleBackColor = true;
             button3.Click += OnClickDirFile1;
-            // 
+            //
             // button2
-            // 
-            button2.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            //
+            button2.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
             button2.AutoSize = true;
             button2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             button2.Location = new System.Drawing.Point(681, 63);
@@ -173,10 +192,10 @@ namespace UoFiddler.Plugin.Compare.UserControls
             button2.Text = "Load";
             button2.UseVisualStyleBackColor = true;
             button2.Click += OnLoad2;
-            // 
+            //
             // button1
-            // 
-            button1.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            //
+            button1.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left;
             button1.AutoSize = true;
             button1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             button1.Location = new System.Drawing.Point(270, 63);
@@ -187,40 +206,112 @@ namespace UoFiddler.Plugin.Compare.UserControls
             button1.Text = "Load";
             button1.UseVisualStyleBackColor = true;
             button1.Click += OnLoad;
-            // 
+            //
             // textBox2
-            // 
-            textBox2.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            //
+            textBox2.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
             textBox2.Location = new System.Drawing.Point(399, 64);
             textBox2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             textBox2.Name = "textBox2";
             textBox2.Size = new System.Drawing.Size(236, 23);
             textBox2.TabIndex = 1;
-            // 
+            //
             // textBox1
-            // 
-            textBox1.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            //
+            textBox1.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left;
             textBox1.Location = new System.Drawing.Point(5, 64);
             textBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             textBox1.Name = "textBox1";
             textBox1.Size = new System.Drawing.Size(223, 23);
             textBox1.TabIndex = 0;
-            // 
+            //
+            // splitContainerDiff
+            //
+            splitContainerDiff.Dock = System.Windows.Forms.DockStyle.Fill;
+            splitContainerDiff.Location = new System.Drawing.Point(0, 0);
+            splitContainerDiff.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            splitContainerDiff.Name = "splitContainerDiff";
+            //
+            // splitContainerDiff.Panel1
+            //
+            splitContainerDiff.Panel1.Controls.Add(diffRichTextBox1);
+            splitContainerDiff.Panel1.Controls.Add(labelDiff1);
+            //
+            // splitContainerDiff.Panel2
+            //
+            splitContainerDiff.Panel2.Controls.Add(diffRichTextBox2);
+            splitContainerDiff.Panel2.Controls.Add(labelDiff2);
+            splitContainerDiff.Size = new System.Drawing.Size(729, 118);
+            splitContainerDiff.SplitterDistance = 362;
+            splitContainerDiff.SplitterWidth = 5;
+            splitContainerDiff.TabIndex = 0;
+            //
+            // labelDiff1
+            //
+            labelDiff1.Dock = System.Windows.Forms.DockStyle.Top;
+            labelDiff1.Location = new System.Drawing.Point(0, 0);
+            labelDiff1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            labelDiff1.Name = "labelDiff1";
+            labelDiff1.Size = new System.Drawing.Size(362, 18);
+            labelDiff1.TabIndex = 0;
+            labelDiff1.Text = "File 1:";
+            //
+            // diffRichTextBox1
+            //
+            diffRichTextBox1.Dock = System.Windows.Forms.DockStyle.Fill;
+            diffRichTextBox1.Location = new System.Drawing.Point(0, 18);
+            diffRichTextBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            diffRichTextBox1.Name = "diffRichTextBox1";
+            diffRichTextBox1.ReadOnly = true;
+            diffRichTextBox1.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.Vertical;
+            diffRichTextBox1.Size = new System.Drawing.Size(362, 100);
+            diffRichTextBox1.TabIndex = 1;
+            diffRichTextBox1.Text = "";
+            diffRichTextBox1.WordWrap = true;
+            //
+            // labelDiff2
+            //
+            labelDiff2.Dock = System.Windows.Forms.DockStyle.Top;
+            labelDiff2.Location = new System.Drawing.Point(0, 0);
+            labelDiff2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            labelDiff2.Name = "labelDiff2";
+            labelDiff2.Size = new System.Drawing.Size(362, 18);
+            labelDiff2.TabIndex = 0;
+            labelDiff2.Text = "File 2:";
+            //
+            // diffRichTextBox2
+            //
+            diffRichTextBox2.Dock = System.Windows.Forms.DockStyle.Fill;
+            diffRichTextBox2.Location = new System.Drawing.Point(0, 18);
+            diffRichTextBox2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            diffRichTextBox2.Name = "diffRichTextBox2";
+            diffRichTextBox2.ReadOnly = true;
+            diffRichTextBox2.ScrollBars = System.Windows.Forms.RichTextBoxScrollBars.Vertical;
+            diffRichTextBox2.Size = new System.Drawing.Size(362, 100);
+            diffRichTextBox2.TabIndex = 1;
+            diffRichTextBox2.Text = "";
+            diffRichTextBox2.WordWrap = true;
+            //
             // CompareCliLocControl
-            // 
+            //
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            Controls.Add(splitContainer1);
+            Controls.Add(splitContainerMain);
             DoubleBuffered = true;
             Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             Name = "CompareCliLocControl";
-            Size = new System.Drawing.Size(729, 377);
-            splitContainer1.Panel1.ResumeLayout(false);
-            splitContainer1.Panel2.ResumeLayout(false);
-            splitContainer1.Panel2.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)splitContainer1).EndInit();
-            splitContainer1.ResumeLayout(false);
+            Size = new System.Drawing.Size(729, 500);
+            splitContainerMain.Panel1.ResumeLayout(false);
+            splitContainerMain.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)splitContainerMain).EndInit();
+            splitContainerMain.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)dataGridView1).EndInit();
+            toolbarPanel.ResumeLayout(false);
+            toolbarPanel.PerformLayout();
+            splitContainerDiff.Panel1.ResumeLayout(false);
+            splitContainerDiff.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)splitContainerDiff).EndInit();
+            splitContainerDiff.ResumeLayout(false);
             ResumeLayout(false);
         }
 
@@ -233,8 +324,14 @@ namespace UoFiddler.Plugin.Compare.UserControls
         private System.Windows.Forms.Button button5;
         private System.Windows.Forms.CheckBox checkBox1;
         private System.Windows.Forms.DataGridView dataGridView1;
-        private System.Windows.Forms.SplitContainer splitContainer1;
+        private System.Windows.Forms.SplitContainer splitContainerMain;
+        private System.Windows.Forms.Panel toolbarPanel;
+        private System.Windows.Forms.SplitContainer splitContainerDiff;
         private System.Windows.Forms.TextBox textBox1;
         private System.Windows.Forms.TextBox textBox2;
+        private System.Windows.Forms.Label labelDiff1;
+        private System.Windows.Forms.Label labelDiff2;
+        private System.Windows.Forms.RichTextBox diffRichTextBox1;
+        private System.Windows.Forms.RichTextBox diffRichTextBox2;
     }
 }

--- a/UoFiddler.Plugin.Compare/UserControls/CompareCliLocControl.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareCliLocControl.cs
@@ -268,6 +268,117 @@ namespace UoFiddler.Plugin.Compare.UserControls
             }
         }
 
+        private void OnSelectionChanged(object sender, EventArgs e)
+        {
+            if (dataGridView1.SelectedRows.Count == 0)
+            {
+                diffRichTextBox1.Clear();
+                diffRichTextBox2.Clear();
+                return;
+            }
+
+            var entry = dataGridView1.SelectedRows[0].DataBoundItem as CompareEntry;
+            if (entry == null)
+            {
+                return;
+            }
+
+            ShowWordDiff(entry.Text1 ?? string.Empty, entry.Text2 ?? string.Empty);
+        }
+
+        private void ShowWordDiff(string text1, string text2)
+        {
+            diffRichTextBox1.Clear();
+            diffRichTextBox2.Clear();
+
+            if (text1 == text2)
+            {
+                diffRichTextBox1.Text = text1;
+                diffRichTextBox2.Text = text2;
+                return;
+            }
+
+            var diff = ComputeWordDiff(text1, text2);
+            bool first1 = true, first2 = true;
+
+            foreach (var (op, word) in diff)
+            {
+                switch (op)
+                {
+                    case WordDiffOp.Equal:
+                        AppendWord(diffRichTextBox1, word, SystemColors.Window, ref first1);
+                        AppendWord(diffRichTextBox2, word, SystemColors.Window, ref first2);
+                        break;
+                    case WordDiffOp.Delete:
+                        AppendWord(diffRichTextBox1, word, Color.FromArgb(255, 200, 200), ref first1);
+                        break;
+                    case WordDiffOp.Insert:
+                        AppendWord(diffRichTextBox2, word, Color.FromArgb(200, 255, 200), ref first2);
+                        break;
+                }
+            }
+
+            diffRichTextBox1.SelectionStart = 0;
+            diffRichTextBox1.SelectionLength = 0;
+            diffRichTextBox2.SelectionStart = 0;
+            diffRichTextBox2.SelectionLength = 0;
+        }
+
+        private static void AppendWord(RichTextBox rtb, string word, Color backColor, ref bool isFirst)
+        {
+            rtb.SelectionStart = rtb.TextLength;
+            rtb.SelectionLength = 0;
+            rtb.SelectionBackColor = backColor;
+            rtb.SelectionColor = SystemColors.WindowText;
+            rtb.SelectedText = isFirst ? word : " " + word;
+            isFirst = false;
+        }
+
+        private enum WordDiffOp { Equal, Delete, Insert }
+
+        private static List<(WordDiffOp Op, string Word)> ComputeWordDiff(string text1, string text2)
+        {
+            string[] a = text1.Split(' ');
+            string[] b = text2.Split(' ');
+            int m = a.Length, n = b.Length;
+
+            var dp = new int[m + 1, n + 1];
+            for (int i = 1; i <= m; i++)
+            {
+                for (int j = 1; j <= n; j++)
+                {
+                    dp[i, j] = a[i - 1] == b[j - 1]
+                        ? dp[i - 1, j - 1] + 1
+                        : Math.Max(dp[i - 1, j], dp[i, j - 1]);
+                }
+            }
+
+            var result = new List<(WordDiffOp, string)>();
+            int ii = m, jj = n;
+            while (ii > 0 || jj > 0)
+            {
+                if (ii > 0 && jj > 0 && a[ii - 1] == b[jj - 1])
+                {
+                    result.Add((WordDiffOp.Equal, a[ii - 1]));
+                    ii--;
+                    jj--;
+                }
+                else if (jj > 0 && (ii == 0 || dp[ii, jj - 1] >= dp[ii - 1, jj]))
+                {
+                    result.Add((WordDiffOp.Insert, b[jj - 1]));
+                    jj--;
+                }
+                else
+                {
+                    result.Add((WordDiffOp.Delete, a[ii - 1]));
+                    ii--;
+                }
+            }
+
+            result.Reverse();
+            return result;
+        }
+
         private void OnHeaderClicked(object sender, DataGridViewCellMouseEventArgs e)
         {
             if (_sortColumn == e.ColumnIndex)

--- a/UoFiddler.Plugin.Compare/UserControls/CompareCliLocControl.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareCliLocControl.cs
@@ -51,7 +51,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
                 return;
             }
 
-            _cliloc1 = new StringList("1", path, decompressFileOneCheckBox.Checked);
+            _cliloc1 = new StringList("1", path, false);
             _cliloc1.Entries.Sort(new StringList.NumberComparer(false));
 
             if (_cliloc2 != null)
@@ -73,7 +73,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
                 return;
             }
 
-            _cliloc2 = new StringList("2", path, decompressFileTwoCheckBox.Checked);
+            _cliloc2 = new StringList("2", path, false);
             _cliloc2.Entries.Sort(new StringList.NumberComparer(false));
 
             if (_cliloc1 != null)

--- a/UoFiddler.Plugin.MultiEditor/UserControls/MultiEditorControl.cs
+++ b/UoFiddler.Plugin.MultiEditor/UserControls/MultiEditorControl.cs
@@ -104,7 +104,6 @@ namespace UoFiddler.Plugin.MultiEditor.UserControls
 
             pictureBoxDrawTiles.MouseWheel += PictureBoxDrawTiles_OnMouseWheel;
             pictureBoxMulti.MouseWheel += PictureBoxMulti_OnMouseWheel;
-            pictureBoxMulti.ContextMenuStrip = null;
 
         }
 
@@ -758,6 +757,45 @@ namespace UoFiddler.Plugin.MultiEditor.UserControls
             fileNode.Nodes.Add(csvNode);
 
             treeViewMultiList.Nodes.Add(fileNode);
+
+            TreeNode uopNode = new TreeNode("multicollection.uop") { Name = "uop" };
+            if (!Multis.HasUopFile)
+            {
+                uopNode.Nodes.Add(new TreeNode("File not found"));
+            }
+            else
+            {
+                for (int i = 0; i < Multis.MaximumMultiIndex; ++i)
+                {
+                    if (Multis.GetUopComponents(i) == MultiComponentList.Empty)
+                    {
+                        continue;
+                    }
+
+                    TreeNode node;
+                    if (dom == null)
+                    {
+                        node = new TreeNode(string.Format("{0,5} (0x{0:X})", i));
+                    }
+                    else
+                    {
+                        XmlNodeList xMultiNodeList = xMultis.SelectNodes("/Multis/Multi[@id='" + i + "']");
+                        string j = "";
+                        foreach (XmlNode xMultiNode in xMultiNodeList)
+                        {
+                            j = xMultiNode.Attributes["name"].Value;
+                        }
+
+                        node = new TreeNode(string.Format("{0,5} (0x{0:X}) {1}", i, j));
+                    }
+
+                    node.Tag = i;
+                    node.Name = i.ToString();
+                    uopNode.Nodes.Add(node);
+                }
+            }
+
+            treeViewMultiList.Nodes.Add(uopNode);
             treeViewMultiList.EndUpdate();
 
             if (!_loaded)
@@ -1695,7 +1733,11 @@ namespace UoFiddler.Plugin.MultiEditor.UserControls
             }
             else
             {
-                _compList = new MultiEditorComponentList(Multis.GetComponents((int)e.Node.Tag), this);
+                MultiComponentList multi = e.Node.Parent?.Name == "uop"
+                    ? Multis.GetUopComponents((int)e.Node.Tag)
+                    : Multis.GetComponents((int)e.Node.Tag);
+
+                _compList = new MultiEditorComponentList(multi, this);
 
                 textBox_SaveToID.Text = e.Node.Tag.ToString();
             }
@@ -1726,7 +1768,9 @@ namespace UoFiddler.Plugin.MultiEditor.UserControls
             {
                 case int nodeTag:
                     {
-                        MultiComponentList list = Multis.GetComponents(nodeTag);
+                        MultiComponentList list = e.Node.Parent?.Name == "uop"
+                            ? Multis.GetUopComponents(nodeTag)
+                            : Multis.GetComponents(nodeTag);
                         toolTip1.SetToolTip(treeViewMultiList, $"{list.Width}x{list.Height} {list.SortedTiles.Length}");
                         break;
                     }

--- a/UoFiddler/Classes/FiddlerOptions.cs
+++ b/UoFiddler/Classes/FiddlerOptions.cs
@@ -85,6 +85,7 @@ namespace UoFiddler.Classes
             MoveFiles(di.GetFiles("Animationlist.xml", SearchOption.TopDirectoryOnly), Options.AppDataPath);
             MoveFiles(di.GetFiles("Multilist.xml", SearchOption.TopDirectoryOnly), Options.AppDataPath);
             MoveFiles(di.GetFiles("Gumplist.xml", SearchOption.TopDirectoryOnly), Options.AppDataPath);
+            MoveFiles(di.GetFiles("DynamicItems.xml", SearchOption.TopDirectoryOnly), Options.AppDataPath);
 
             di = new DirectoryInfo(Path.Combine(Application.StartupPath, "plugins"));
             MoveFiles(di.GetFiles("*.xml", SearchOption.TopDirectoryOnly), plugInPath);
@@ -95,6 +96,8 @@ namespace UoFiddler.Classes
                 Logger.Fatal("Can't find default profile file: {FileName}", fileName);
                 throw new FileNotFoundException($"Can't load default profile file {fileName}", "Options_default.xml");
             }
+
+            DynamicItemsConfig.EnsureLoaded();
         }
 
         public static void SaveProfile()

--- a/UoFiddler/Classes/FiddlerOptions.cs
+++ b/UoFiddler/Classes/FiddlerOptions.cs
@@ -129,11 +129,6 @@ namespace UoFiddler.Classes
             elem = dom.CreateElement("ItemClip");
             elem.SetAttribute("active", Options.ArtItemClip.ToString());
             sr.AppendChild(elem);
-            comment = dom.CreateComment("NewClilocFormat should cliloc be decompressed before reading");
-            sr.AppendChild(comment);
-            elem = dom.CreateElement("NewClilocFormat");
-            elem.SetAttribute("active", Options.NewClilocFormat.ToString());
-            sr.AppendChild(elem);
             comment = dom.CreateComment("CacheData should mul entries be cached for faster load");
             sr.AppendChild(comment);
             elem = dom.CreateElement("CacheData");
@@ -324,12 +319,6 @@ namespace UoFiddler.Classes
             {
                 Options.ArtItemSizeWidth = int.Parse(elem.GetAttribute("width"));
                 Options.ArtItemSizeHeight = int.Parse(elem.GetAttribute("height"));
-            }
-
-            elem = (XmlElement)xOptions.SelectSingleNode("NewClilocFormat");
-            if (elem != null)
-            {
-                Options.NewClilocFormat = bool.Parse(elem.GetAttribute("active"));
             }
 
             elem = (XmlElement)xOptions.SelectSingleNode("ItemClip");

--- a/UoFiddler/DynamicItems.xml
+++ b/UoFiddler/DynamicItems.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Items listed here are flagged as dynamic (Flags=1) when importing from WSC format.
+  Dynamic items spawn as interactive world objects when a house deed is placed
+  (e.g. doors that can be opened, functional crafting stations, placeable signs).
+
+  Syntax:
+    <Item id="0x0E8" comment="optional description" />
+    <Range from="0x0E8" to="0x0F7" comment="optional description" />
+
+  IDs may be in hex (0x...) or decimal.
+-->
+<DynamicItems>
+  <!-- Doors (from TileData Door flag) -->
+  <Range from="0x00E8" to="0x00F7" comment="stone wall, secret door" />
+  <Range from="0x0314" to="0x0363" comment="dungeon wall, secret door, stone wall, wooden wall" />
+  <Range from="0x0675" to="0x0691" comment="metal door, barred metal door" />
+  <Range from="0x0693" to="0x06F4" comment="barred metal door, rattan door, wooden door, metal door" />
+  <Range from="0x0824" to="0x0833" comment="iron gate" />
+  <Range from="0x0839" to="0x0843" comment="wooden gate" />
+  <Item id="0x0845" comment="wooden gate" />
+  <Range from="0x0847" to="0x0848" comment="wooden gate" />
+  <Range from="0x084C" to="0x085B" comment="iron gate" />
+  <Range from="0x0866" to="0x0872" comment="wooden gate" />
+  <Range from="0x0874" to="0x0875" comment="wooden gate" />
+  <Range from="0x190E" to="0x190F" comment="bar door" />
+  <Range from="0x1FED" to="0x1FFC" comment="barred metal door" />
+  <Range from="0x241F" to="0x2424" comment="door" />
+  <Item id="0x26F4" comment="door" />
+  <Item id="0x26F6" comment="door" />
+  <Range from="0x2A05" to="0x2A1C" comment="sliding door, secret door" />
+  <Range from="0x2D46" to="0x2D49" comment="wooden door closed, wooden door opened" />
+  <Range from="0x2D63" to="0x2D6E" comment="simple door, ornate door, plain door" />
+  <Range from="0x2FE2" to="0x2FE5" comment="moon door" />
+  <Range from="0x319C" to="0x31AF" comment="door" />
+  <Range from="0x35E7" to="0x35E8" comment="door" />
+  <Range from="0x3640" to="0x3646" comment="door" />
+  <Range from="0x367B" to="0x369A" comment="door" />
+  <Range from="0x409B" to="0x40A2" comment="Wallset3 door" />
+  <Range from="0x410C" to="0x4113" comment="GargoyleDoor" />
+  <Range from="0x41C2" to="0x41C9" comment="Wallset2 door" />
+  <Range from="0x41CF" to="0x41D6" comment="Wallset1 door" />
+  <Range from="0x436E" to="0x437D" comment="door A/B/C/D variants" />
+  <Range from="0x46DD" to="0x46E4" comment="RuinDoor" />
+  <Range from="0x4D1A" to="0x4D29" comment="QueenDoor" />
+  <Range from="0x50C8" to="0x50D7" comment="door" />
+  <Range from="0x5128" to="0x5129" comment="QC wall door" />
+  <Range from="0x5142" to="0x5149" comment="door" />
+  <Range from="0x9AD7" to="0x9AE6" comment="metal door" />
+  <Range from="0x9B3C" to="0x9B4B" comment="metal door" />
+  <Range from="0xA4BF" to="0xA4CB" comment="wooden gate" />
+  <!-- House signs -->
+  <Range from="0x0BCF" to="0x0BD2" comment="house sign" />
+  <!-- Chests -->
+  <Item id="0x09AB" comment="chest" />
+  <Range from="0x0E40" to="0x0E43" comment="chest" />
+  <Item id="0x0E7C" comment="chest" />
+  <!-- Anvil and forge -->
+  <Range from="0x0FAF" to="0x0FB1" comment="anvil, forge" />
+  <!-- Archery butte -->
+  <Range from="0x100A" to="0x100B" comment="archery butte" />
+  <!-- Spinning wheel -->
+  <Range from="0x1015" to="0x1017" comment="spinning wheel" />
+  <Range from="0x1019" to="0x101E" comment="spinning wheel" />
+  <!-- Upright loom -->
+  <Range from="0x105F" to="0x1066" comment="upright loom" />
+  <!-- Training dummy -->
+  <Item id="0x1070" comment="training dummy" />
+  <Item id="0x1074" comment="training dummy" />
+  <!-- More spinning wheel -->
+  <Range from="0x10A4" to="0x10A6" comment="spinning wheel" />
+  <!-- Forge parts -->
+  <Range from="0x197A" to="0x1999" comment="forge parts" />
+  <Range from="0x19A0" to="0x19A9" comment="forge parts" />
+  <!-- Pickpocket dip -->
+  <Item id="0x1EC0" comment="pickpocket dip" />
+  <Item id="0x1EC3" comment="pickpocket dip" />
+</DynamicItems>

--- a/UoFiddler/Forms/AboutBoxForm.resx
+++ b/UoFiddler/Forms/AboutBoxForm.resx
@@ -118,7 +118,14 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="richTextBox1.Text" xml:space="preserve">
-    <value>Version 4.18.1
+    <value>Version 4.18.2
+- Fixed WSC multi import where file has absolute coordinates. Now all coordinates are converted to relative ones.
+- Added DynamicItems.xml with list of items that should be marked as dynamic when importing multis from WSC.
+- Added support for viewing and importing Multicollection.uop multis (there is no save option for now).
+- Improved CliLoc comparison. It shows word diff now with highlights.
+- Removed `New cliloc format` option. Cliloc format is now autodetected.
+
+Version 4.18.1
 - Mass import plugin now allows importing PNG and JPEG.
 - Invalid entries in Animationlist.xml will now be skipped nad will result in a message about the problem.
 - Multi editor now has additional form with shortcut list.

--- a/UoFiddler/Forms/OptionsForm.Designer.cs
+++ b/UoFiddler/Forms/OptionsForm.Designer.cs
@@ -47,7 +47,6 @@ namespace UoFiddler.Forms
             numericUpDownItemSizeWidth = new System.Windows.Forms.NumericUpDown();
             checkBoxCacheData = new System.Windows.Forms.CheckBox();
             groupBox2 = new System.Windows.Forms.GroupBox();
-            checkBoxNewClilocFormat = new System.Windows.Forms.CheckBox();
             checkBoxPolSoundIdOffset = new System.Windows.Forms.CheckBox();
             checkBoxuseDiff = new System.Windows.Forms.CheckBox();
             checkBoxNewMapSize = new System.Windows.Forms.CheckBox();
@@ -169,7 +168,6 @@ namespace UoFiddler.Forms
             // 
             // groupBox2
             // 
-            groupBox2.Controls.Add(checkBoxNewClilocFormat);
             groupBox2.Controls.Add(checkBoxPolSoundIdOffset);
             groupBox2.Controls.Add(checkBoxuseDiff);
             groupBox2.Controls.Add(checkBoxNewMapSize);
@@ -178,23 +176,11 @@ namespace UoFiddler.Forms
             groupBox2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             groupBox2.Name = "groupBox2";
             groupBox2.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            groupBox2.Size = new System.Drawing.Size(258, 157);
+            groupBox2.Size = new System.Drawing.Size(258, 132);
             groupBox2.TabIndex = 3;
             groupBox2.TabStop = false;
             groupBox2.Text = "Misc";
-            // 
-            // checkBoxNewClilocFormat
-            // 
-            checkBoxNewClilocFormat.AutoSize = true;
-            checkBoxNewClilocFormat.Location = new System.Drawing.Point(7, 123);
-            checkBoxNewClilocFormat.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            checkBoxNewClilocFormat.Name = "checkBoxNewClilocFormat";
-            checkBoxNewClilocFormat.Size = new System.Drawing.Size(120, 19);
-            checkBoxNewClilocFormat.TabIndex = 8;
-            checkBoxNewClilocFormat.Text = "New cliloc format";
-            toolTip1.SetToolTip(checkBoxNewClilocFormat, "For client version 7.0.104 and newer this needs to be checked. It allows reading of new cliloc format. This option has only partial support so saving file will only produce old cliloc format.");
-            checkBoxNewClilocFormat.UseVisualStyleBackColor = true;
-            // 
+            //
             // checkBoxPolSoundIdOffset
             // 
             checkBoxPolSoundIdOffset.AutoSize = true;
@@ -654,7 +640,6 @@ namespace UoFiddler.Forms
         private System.Windows.Forms.CheckBox checkBoxPolSoundIdOffset;
         private System.Windows.Forms.Button buttonClose;
         private System.Windows.Forms.CheckBox checkboxRemoveTileBorder;
-        private System.Windows.Forms.CheckBox checkBoxNewClilocFormat;
         private System.Windows.Forms.Label PreviewBackgroundColorLabel;
         private System.Windows.Forms.Button PreviewBackgroundColorButton;
     }

--- a/UoFiddler/Forms/OptionsForm.cs
+++ b/UoFiddler/Forms/OptionsForm.cs
@@ -84,7 +84,6 @@ namespace UoFiddler.Forms
             cmdtext.Text = Options.MapCmd;
             argstext.Text = Options.MapArgs;
             textBoxOutputPath.Text = Options.OutputPath;
-            checkBoxNewClilocFormat.Checked = Options.NewClilocFormat;
         }
 
         private void OnClickApply(object sender, EventArgs e)
@@ -127,11 +126,6 @@ namespace UoFiddler.Forms
                 Options.ArtItemSizeHeight = (int)numericUpDownItemSizeHeight.Value;
 
                 _updateItemsTabAction();
-            }
-
-            if (checkBoxNewClilocFormat.Checked != Options.NewClilocFormat)
-            {
-                Options.NewClilocFormat = checkBoxNewClilocFormat.Checked;
             }
 
             if (checkBoxItemClip.Checked != Options.ArtItemClip)

--- a/UoFiddler/Multilist.xml
+++ b/UoFiddler/Multilist.xml
@@ -251,6 +251,41 @@
   <Multi name="Foundation [18x16]" id="5241" type="3" />
   <Multi name="Foundation [18x17]" id="5242" type="3" />
   <Multi name="Foundation [18x18]" id="5243" type="3" />
+  <Multi name="Foundation [24x24]" id="5244" type="1" />
+  <Multi name="Foundation [31x31]" id="5245" type="1" />
+  <Multi name="Trinsic Keep" id="5246" type="1" />
+  <Multi name="Gothic Rose Castle" id="5247" type="1" />
+  <Multi name="Elsa Castle" id="5248" type="1" />
+  <Multi name="Spires" id="5249" type="1" />
+  <Multi name="Castle Of Oceania" id="5250" type="1" />
+  <Multi name="Feudal Castle" id="5251" type="1" />
+  <Multi name="Robins Nest" id="5252" type="1" />
+  <Multi name="Traditional Keep" id="5253" type="1" />
+  <Multi name="Villa Crowley" id="5254" type="1" />
+  <Multi name="Darkthorn Keep" id="5255" type="1" />
+  <Multi name="Sandalwood Keep" id="5256" type="1" />
+  <Multi name="Casa Moga" id="5257" type="1" />
+  <Multi name="Robins Roost" id="5258" type="1" />
+  <Multi name="Camelot" id="5259" type="1" />
+  <Multi name="Lacrimae In Caelo" id="5260" type="1" />
+  <Multi name="Okinawa Sweet Dream Castle" id="5261" type="1" />
+  <Multi name="The Sandstone Castle" id="5262" type="1" />
+  <Multi name="Grimswind Sisters" id="5263" type="1" />
+  <Multi name="Fortress Of Lestat" id="5264" type="1" />
+  <Multi name="Citadel Of The Far East" id="5265" type="1" />
+  <Multi name="Keep Incarcerated" id="5266" type="1" />
+  <Multi name="Sally Trees Refurbished Keep" id="5267" type="1" />
+  <Multi name="Desert Rose" id="5268" type="1" />
+  <Multi name="The Clovers Keep" id="5269" type="1" />
+  <Multi name="The Sorceres Castle" id="5270" type="1" />
+  <Multi name="The Castle Cascade" id="5271" type="1" />
+  <Multi name="The House Built On The Ruins" id="5272" type="1" />
+  <Multi name="The Sandstone Fortress Of Grand" id="5273" type="1" />
+  <Multi name="The Dragonstone Castle" id="5274" type="1" />
+  <Multi name="The Terrace Gardens" id="5275" type="1" />
+  <Multi name="The Keep Calm And Carry On Keep" id="5276" type="1" />
+  <Multi name="The Ravenloft Keep" id="5277" type="1" />
+  <Multi name="The Queens Retreat Keep" id="5278" type="1" />
   <Multi name="New Player Quest Cam" id="7500" type="2" />
 </Multis>
 

--- a/UoFiddler/Options_default.xml
+++ b/UoFiddler/Options_default.xml
@@ -4,8 +4,6 @@
   <ItemSize width="48" height="48" />
   <!--ItemClip images in items tab shrinked or clipped-->
   <ItemClip active="True" />
-  <!--NewClilocFormat should cliloc be decompressed before reading-->
-  <NewClilocFormat active="False" />
   <!--CacheData should mul entries be cached for faster load-->
   <CacheData active="True" />
   <!--NewMapSize Felucca/Trammel width 7168?-->

--- a/UoFiddler/UoFiddler.csproj
+++ b/UoFiddler/UoFiddler.csproj
@@ -140,6 +140,9 @@
 		<Content Include="Multilist.xml">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</Content>
+		<Content Include="DynamicItems.xml">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+		</Content>
 		<EmbeddedResource Include="Resources\UOFiddler.jpg" />
 		<EmbeddedResource Include="Resources\UOFiddlerIcon.ico" />
 		<None Include="Options_default.xml">

--- a/UoFiddler/UoFiddler.csproj
+++ b/UoFiddler/UoFiddler.csproj
@@ -9,9 +9,9 @@
 		<AssemblyTitle>UoFiddler</AssemblyTitle>
 		<Product>UoFiddler</Product>
 		<Copyright>Copyright © 2026</Copyright>
-		<AssemblyVersion>4.18.1</AssemblyVersion>
-		<FileVersion>4.18.1</FileVersion>
-		<Version>4.18.1</Version>
+		<AssemblyVersion>4.18.2</AssemblyVersion>
+		<FileVersion>4.18.2</FileVersion>
+		<Version>4.18.2</Version>
 		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
 	</PropertyGroup>
 	<PropertyGroup>


### PR DESCRIPTION
* Fixed WSC multi import where file has absolute coordinates. Now all coordinates are converted to relative ones.
* Added DynamicItems.xml with list of items that should be marked as dynamic when importing multis from WSC.
* Added support for viewing and importing Multicollection.uop multis (there is no save option for now).
* Improved CliLoc comparison. It shows word diff now with highlights.
* Removed `New cliloc format` option. Cliloc format is now autodetected.