### PR TITLE
Option to set export file name template hexadecimal/decimal (defaults to hexadecimal)

### DIFF
--- a/UoFiddler.Controls/Classes/Options.cs
+++ b/UoFiddler.Controls/Classes/Options.cs
@@ -43,6 +43,18 @@ namespace UoFiddler.Controls.Classes
         public static bool DarkMode { get; set; }
 
         /// <summary>
+        /// When true, exported image filenames embed the ID in hexadecimal form (e.g. "Item 0x00FF.png").
+        /// When false, decimal form is used. Runtime flag set from AppSettings at startup.
+        /// </summary>
+        public static bool ExportFilenameInHex { get; set; } = true;
+
+        /// <summary>
+        /// When <see cref="ExportFilenameInHex"/> is false, controls whether decimal IDs are zero-padded
+        /// to 5 digits ("00255") or written without padding ("255"). Runtime flag set from AppSettings.
+        /// </summary>
+        public static bool ExportFilenameDecimalPadded { get; set; } = true;
+
+        /// <summary>
         /// Defines the cmd to Send Client to Loc
         /// </summary>
         public static string MapCmd { get; set; } = ".goforce";

--- a/UoFiddler.Controls/Classes/Utils.cs
+++ b/UoFiddler.Controls/Classes/Utils.cs
@@ -64,6 +64,23 @@ namespace UoFiddler.Controls.Classes
             return int.TryParse(text, NumberStyles.Integer, null, out result);
         }
 
+        /// <summary>
+        /// Formats an ID for inclusion in an exported filename, honoring the user's
+        /// hex/decimal preference in <see cref="Options.ExportFilenameInHex"/> and
+        /// <see cref="Options.ExportFilenameDecimalPadded"/>.
+        /// </summary>
+        public static string FormatExportId(int id)
+        {
+            if (Options.ExportFilenameInHex)
+            {
+                return $"0x{id:X4}";
+            }
+
+            return Options.ExportFilenameDecimalPadded
+                ? id.ToString("D5")
+                : id.ToString();
+        }
+
         public static unsafe Bitmap ConvertBmp(Bitmap bmp)
         {
             BitmapData bd = bmp.LockBits(new Rectangle(0, 0, bmp.Width, bmp.Height), ImageLockMode.ReadOnly, PixelFormat.Format16bppArgb1555);

--- a/UoFiddler.Controls/Forms/AnimationEditForm.cs
+++ b/UoFiddler.Controls/Forms/AnimationEditForm.cs
@@ -1191,7 +1191,7 @@ namespace UoFiddler.Controls.Forms
             }
 
             string path = Options.OutputPath;
-            string fileName = Path.Combine(path, $"anim{_fileType}_0x{_currentBody:X}.vd");
+            string fileName = Path.Combine(path, $"anim{_fileType}_{Utils.FormatExportId(_currentBody)}.vd");
             AnimationEdit.ExportToVD(_fileType, _currentBody, fileName);
 
             FileSavedDialog.Show(FindForm(), Options.OutputPath, "Animation saved successfully.");
@@ -2240,7 +2240,7 @@ namespace UoFiddler.Controls.Forms
                         continue;
                     }
 
-                    string fileName = Path.Combine(dialog.SelectedPath, $"anim{_fileType}_0x{index:X}.vd");
+                    string fileName = Path.Combine(dialog.SelectedPath, $"anim{_fileType}_{Utils.FormatExportId(index)}.vd");
                     AnimationEdit.ExportToVD(_fileType, index, fileName);
                 }
 

--- a/UoFiddler.Controls/Forms/ItemDetailForm.cs
+++ b/UoFiddler.Controls/Forms/ItemDetailForm.cs
@@ -246,7 +246,7 @@ namespace UoFiddler.Controls.Forms
             }
 
             string fileExtension = Utils.GetFileExtensionFor(imageFormat);
-            string fileName = Path.Combine(Options.OutputPath, $"Item 0x{_index:X}.{fileExtension}");
+            string fileName = Path.Combine(Options.OutputPath, $"Item {Utils.FormatExportId(_index)}.{fileExtension}");
 
             using (Bitmap bit = new Bitmap(Art.GetStatic(_index).Width, Art.GetStatic(_index).Height))
             {

--- a/UoFiddler.Controls/UserControls/AnimDataControl.cs
+++ b/UoFiddler.Controls/UserControls/AnimDataControl.cs
@@ -679,7 +679,7 @@ namespace UoFiddler.Controls.UserControls
         {
             if (_selAnimdataEntry != null)
             {
-                var outputFile = Path.Combine(Options.OutputPath, $"AnimData 0x{_currentSelect:X}.gif");
+                var outputFile = Path.Combine(Options.OutputPath, $"AnimData {Utils.FormatExportId(_currentSelect)}.gif");
                 MainPictureBox.Frames.ToGif(outputFile, delay: 150, showFrameBounds: MainPictureBox.ShowFrameBounds);
                 MessageBox.Show($"Saved to {outputFile}");
             }

--- a/UoFiddler.Controls/UserControls/AnimationListControl.cs
+++ b/UoFiddler.Controls/UserControls/AnimationListControl.cs
@@ -872,7 +872,7 @@ namespace UoFiddler.Controls.UserControls
             }
 
             string fileExtension = Utils.GetFileExtensionFor(imageFormat);
-            string fileName = Path.Combine(Options.OutputPath, $"{what} {_currentSelect}.{fileExtension}");
+            string fileName = Path.Combine(Options.OutputPath, $"{what} {Utils.FormatExportId(_currentSelect)}.{fileExtension}");
 
             Bitmap sourceBitmap = MainPictureBox.CurrentFrame?.Bitmap;
 
@@ -926,7 +926,7 @@ namespace UoFiddler.Controls.UserControls
             }
 
             string fileExtension = Utils.GetFileExtensionFor(imageFormat);
-            string fileName = Path.Combine(Options.OutputPath, $"{what} {_currentSelect}");
+            string fileName = Path.Combine(Options.OutputPath, $"{what} {Utils.FormatExportId(_currentSelect)}");
 
             for (int i = 0; i < MainPictureBox.Frames?.Count; ++i)
             {
@@ -981,7 +981,7 @@ namespace UoFiddler.Controls.UserControls
             }
 
             string fileExtension = Utils.GetFileExtensionFor(imageFormat);
-            string fileName = Path.Combine(Options.OutputPath, $"{what} {_currentSelect}");
+            string fileName = Path.Combine(Options.OutputPath, $"{what} {Utils.FormatExportId(_currentSelect)}");
 
             Bitmap bit = MainPictureBox.Frames[(int)listView1.SelectedItems[0].Tag].Bitmap;
             using (Bitmap newBitmap = new Bitmap(bit.Width, bit.Height))

--- a/UoFiddler.Controls/UserControls/FontsControl.cs
+++ b/UoFiddler.Controls/UserControls/FontsControl.cs
@@ -209,8 +209,8 @@ namespace UoFiddler.Controls.UserControls
             string path = Options.OutputPath;
             string fileType = (int)treeView.SelectedNode.Parent.Tag == 1 ? "Unicode" : "ASCII";
             string fileName = (int)treeView.SelectedNode.Parent.Tag == 1
-                ? Path.Combine(path, $"{fileType} {(int)treeView.SelectedNode.Tag} 0x{FontsTileView.SelectedIndices[0]:X}.tiff")
-                : Path.Combine(path, $"{fileType} {(int)treeView.SelectedNode.Tag} 0x{_fonts[FontsTileView.SelectedIndices[0]] + AsciiFontOffset:X}.tiff");
+                ? Path.Combine(path, $"{fileType} {(int)treeView.SelectedNode.Tag} {Utils.FormatExportId(FontsTileView.SelectedIndices[0])}.tiff")
+                : Path.Combine(path, $"{fileType} {(int)treeView.SelectedNode.Tag} {Utils.FormatExportId(_fonts[FontsTileView.SelectedIndices[0]] + AsciiFontOffset)}.tiff");
 
             if ((int)treeView.SelectedNode.Parent.Tag == 1)
             {

--- a/UoFiddler.Controls/UserControls/GumpControl.cs
+++ b/UoFiddler.Controls/UserControls/GumpControl.cs
@@ -734,7 +734,7 @@ namespace UoFiddler.Controls.UserControls
         private static void ExportGumpImage(int index, ImageFormat imageFormat)
         {
             string fileExtension = Utils.GetFileExtensionFor(imageFormat);
-            string fileName = Path.Combine(Options.OutputPath, $"Gump 0x{index:X4}.{fileExtension}");
+            string fileName = Path.Combine(Options.OutputPath, $"Gump {Utils.FormatExportId(index)}.{fileExtension}");
 
             using (Bitmap bit = new Bitmap(Gumps.GetGump(index)))
             {
@@ -792,7 +792,7 @@ namespace UoFiddler.Controls.UserControls
                         continue;
                     }
 
-                    string fileName = Path.Combine(dialog.SelectedPath, $"Gump 0x{index:X4}.{fileExtension}");
+                    string fileName = Path.Combine(dialog.SelectedPath, $"Gump {Utils.FormatExportId(index)}.{fileExtension}");
                     var gump = Gumps.GetGump(index);
                     if (gump is null)
                     {

--- a/UoFiddler.Controls/UserControls/ItemsControl.cs
+++ b/UoFiddler.Controls/UserControls/ItemsControl.cs
@@ -746,7 +746,7 @@ namespace UoFiddler.Controls.UserControls
             }
 
             string fileExtension = Utils.GetFileExtensionFor(imageFormat);
-            string fileName = Path.Combine(Options.OutputPath, $"Item 0x{index:X4}.{fileExtension}");
+            string fileName = Path.Combine(Options.OutputPath, $"Item {Utils.FormatExportId(index)}.{fileExtension}");
 
             using (Bitmap bit = new Bitmap(Art.GetStatic(index)))
             {
@@ -821,7 +821,7 @@ namespace UoFiddler.Controls.UserControls
                             continue;
                         }
 
-                        string fileName = Path.Combine(dialog.SelectedPath, $"Item 0x{index:X4}.{fileExtension}");
+                        string fileName = Path.Combine(dialog.SelectedPath, $"Item {Utils.FormatExportId(index)}.{fileExtension}");
                         var artBitmap = Art.GetStatic(index);
                         if (artBitmap is null)
                         {

--- a/UoFiddler.Controls/UserControls/LandTilesControl.cs
+++ b/UoFiddler.Controls/UserControls/LandTilesControl.cs
@@ -561,7 +561,7 @@ namespace UoFiddler.Controls.UserControls
             }
 
             string fileExtension = Utils.GetFileExtensionFor(imageFormat);
-            string fileName = Path.Combine(Options.OutputPath, $"Landtile 0x{index:X4}.{fileExtension}");
+            string fileName = Path.Combine(Options.OutputPath, $"Landtile {Utils.FormatExportId(index)}.{fileExtension}");
 
             using (Bitmap bit = new Bitmap(Art.GetLand(index)))
             {
@@ -652,7 +652,7 @@ namespace UoFiddler.Controls.UserControls
                         continue;
                     }
 
-                    string fileName = Path.Combine(dialog.SelectedPath, $"Landtile 0x{index:X4}.{fileExtension}");
+                    string fileName = Path.Combine(dialog.SelectedPath, $"Landtile {Utils.FormatExportId(index)}.{fileExtension}");
                     var landTile = Art.GetLand(index);
                     if (landTile is null)
                     {

--- a/UoFiddler.Controls/UserControls/LightControl.cs
+++ b/UoFiddler.Controls/UserControls/LightControl.cs
@@ -349,7 +349,7 @@ namespace UoFiddler.Controls.UserControls
 
             string path = Options.OutputPath;
             int i = (int)treeViewLights.SelectedNode.Tag;
-            string fileName = Path.Combine(path, $"Light {i}.bmp");
+            string fileName = Path.Combine(path, $"Light {Utils.FormatExportId(i)}.bmp");
             Light.GetLight(i).Save(fileName, ImageFormat.Bmp);
             FileSavedDialog.Show(FindForm(), fileName, "Light saved successfully.");
         }
@@ -363,7 +363,7 @@ namespace UoFiddler.Controls.UserControls
 
             string path = Options.OutputPath;
             int i = (int)treeViewLights.SelectedNode.Tag;
-            string fileName = Path.Combine(path, $"Light {i}.tiff");
+            string fileName = Path.Combine(path, $"Light {Utils.FormatExportId(i)}.tiff");
             Ultima.Light.GetLight(i).Save(fileName, ImageFormat.Tiff);
             FileSavedDialog.Show(FindForm(), fileName, "Light saved successfully.");
         }
@@ -377,7 +377,7 @@ namespace UoFiddler.Controls.UserControls
 
             string path = Options.OutputPath;
             int i = (int)treeViewLights.SelectedNode.Tag;
-            string fileName = Path.Combine(path, $"Light {i}.jpg");
+            string fileName = Path.Combine(path, $"Light {Utils.FormatExportId(i)}.jpg");
             Ultima.Light.GetLight(i).Save(fileName, ImageFormat.Jpeg);
             FileSavedDialog.Show(FindForm(), fileName, "Light saved successfully.");
         }

--- a/UoFiddler.Controls/UserControls/MultisControl.cs
+++ b/UoFiddler.Controls/UserControls/MultisControl.cs
@@ -469,7 +469,7 @@ namespace UoFiddler.Controls.UserControls
 
             string fileExtension = Utils.GetFileExtensionFor(imageFormat);
             string floorSuffix = HeightChangeMulti.Value > 0 ? $"_Z{HeightChangeMulti.Value:000}" : string.Empty;
-            string fileName = Path.Combine(Options.OutputPath, $"Multi 0x{int.Parse(TreeViewMulti.SelectedNode.Name):X4}{floorSuffix}.{fileExtension}");
+            string fileName = Path.Combine(Options.OutputPath, $"Multi {Utils.FormatExportId(int.Parse(TreeViewMulti.SelectedNode.Name))}{floorSuffix}.{fileExtension}");
             SaveImage(_mulBitmap, fileName, imageFormat, backgroundColor);
             FileSavedDialog.Show(FindForm(), fileName, "Multi saved successfully.");
         }
@@ -539,7 +539,7 @@ namespace UoFiddler.Controls.UserControls
             int id = int.Parse(TreeViewMulti.SelectedNode.Name);
 
             string path = Options.OutputPath;
-            string fileName = Path.Combine(path, $"Multi 0x{id:X}.txt");
+            string fileName = Path.Combine(path, $"Multi {Utils.FormatExportId(id)}.txt");
             multi.ExportToTextFile(fileName);
 
             FileSavedDialog.Show(FindForm(), fileName, "Multi saved successfully.");
@@ -561,7 +561,7 @@ namespace UoFiddler.Controls.UserControls
             int id = int.Parse(TreeViewMulti.SelectedNode.Name);
 
             string path = Options.OutputPath;
-            string fileName = Path.Combine(path, $"Multi 0x{id:X}.wsc");
+            string fileName = Path.Combine(path, $"Multi {Utils.FormatExportId(id)}.wsc");
             multi.ExportToWscFile(fileName);
 
             FileSavedDialog.Show(FindForm(), fileName, "Multi saved successfully.");
@@ -583,7 +583,7 @@ namespace UoFiddler.Controls.UserControls
             int id = int.Parse(TreeViewMulti.SelectedNode.Name);
 
             string path = Options.OutputPath;
-            string fileName = Path.Combine(path, $"Multi 0x{id:X}.uoa");
+            string fileName = Path.Combine(path, $"Multi {Utils.FormatExportId(id)}.uoa");
             multi.ExportToUOAFile(fileName);
 
             FileSavedDialog.Show(FindForm(), fileName, "Multi saved successfully.");
@@ -687,7 +687,7 @@ namespace UoFiddler.Controls.UserControls
                     }
 
                     const int maximumMultiHeight = 127;
-                    string fileName = Path.Combine(dialog.SelectedPath, $"Multi 0x{index:X4}.{fileExtension}");
+                    string fileName = Path.Combine(dialog.SelectedPath, $"Multi {Utils.FormatExportId(index)}.{fileExtension}");
 
                     using (Bitmap multiBitmap = ((MultiComponentList)_refMarker.TreeViewMulti.Nodes[i].Tag)?.GetImage(maximumMultiHeight))
                     {
@@ -727,7 +727,7 @@ namespace UoFiddler.Controls.UserControls
                         continue;
                     }
 
-                    string fileName = Path.Combine(dialog.SelectedPath, $"Multi 0x{index:X4}.txt");
+                    string fileName = Path.Combine(dialog.SelectedPath, $"Multi {Utils.FormatExportId(index)}.txt");
                     multi.ExportToTextFile(fileName);
                 }
 
@@ -760,7 +760,7 @@ namespace UoFiddler.Controls.UserControls
                         continue;
                     }
 
-                    string fileName = Path.Combine(dialog.SelectedPath, $"Multi 0x{index:X4}.uoa");
+                    string fileName = Path.Combine(dialog.SelectedPath, $"Multi {Utils.FormatExportId(index)}.uoa");
                     multi.ExportToUOAFile(fileName);
                 }
 
@@ -793,7 +793,7 @@ namespace UoFiddler.Controls.UserControls
                         continue;
                     }
 
-                    string fileName = Path.Combine(dialog.SelectedPath, $"Multi 0x{index:X4}.wsc");
+                    string fileName = Path.Combine(dialog.SelectedPath, $"Multi {Utils.FormatExportId(index)}.wsc");
                     multi.ExportToWscFile(fileName);
                 }
 
@@ -859,7 +859,7 @@ namespace UoFiddler.Controls.UserControls
                         continue;
                     }
 
-                    string fileName = Path.Combine(dialog.SelectedPath, $"Multi 0x{index:X4}.uox3");
+                    string fileName = Path.Combine(dialog.SelectedPath, $"Multi {Utils.FormatExportId(index)}.uox3");
                     multi.ExportToUox3File(fileName);
                 }
 
@@ -904,7 +904,7 @@ namespace UoFiddler.Controls.UserControls
             int id = int.Parse(TreeViewMulti.SelectedNode.Name);
 
             string path = Options.OutputPath;
-            string fileName = Path.Combine(path, $"Multi 0x{id:X4}.uox3");
+            string fileName = Path.Combine(path, $"Multi {Utils.FormatExportId(id)}.uox3");
             multi.ExportToUox3File(fileName);
             FileSavedDialog.Show(FindForm(), fileName, "Multi saved successfully.");
         }
@@ -1288,7 +1288,7 @@ namespace UoFiddler.Controls.UserControls
             string fileExtension = Utils.GetFileExtensionFor(imageFormat);
             string floorSuffix = HeightChangeUop.Value > 0 ? $"_Z{HeightChangeUop.Value:000}" : string.Empty;
             int id = int.Parse(treeViewUop.SelectedNode.Name);
-            string fileName = Path.Combine(Options.OutputPath, $"UopMulti 0x{id:X4}{floorSuffix}.{fileExtension}");
+            string fileName = Path.Combine(Options.OutputPath, $"UopMulti {Utils.FormatExportId(id)}{floorSuffix}.{fileExtension}");
             SaveImage(_uopBitmap, fileName, imageFormat, backgroundColor);
             FileSavedDialog.Show(FindForm(), fileName, "Multi saved successfully.");
         }
@@ -1301,7 +1301,7 @@ namespace UoFiddler.Controls.UserControls
             }
 
             int id = int.Parse(treeViewUop.SelectedNode.Name);
-            string fileName = Path.Combine(Options.OutputPath, $"UopMulti 0x{id:X}.txt");
+            string fileName = Path.Combine(Options.OutputPath, $"UopMulti {Utils.FormatExportId(id)}.txt");
             multi.ExportToTextFile(fileName);
             FileSavedDialog.Show(FindForm(), fileName, "Multi saved successfully.");
         }
@@ -1314,7 +1314,7 @@ namespace UoFiddler.Controls.UserControls
             }
 
             int id = int.Parse(treeViewUop.SelectedNode.Name);
-            string fileName = Path.Combine(Options.OutputPath, $"UopMulti 0x{id:X}.uoa");
+            string fileName = Path.Combine(Options.OutputPath, $"UopMulti {Utils.FormatExportId(id)}.uoa");
             multi.ExportToUOAFile(fileName);
             FileSavedDialog.Show(FindForm(), fileName, "Multi saved successfully.");
         }
@@ -1327,7 +1327,7 @@ namespace UoFiddler.Controls.UserControls
             }
 
             int id = int.Parse(treeViewUop.SelectedNode.Name);
-            string fileName = Path.Combine(Options.OutputPath, $"UopMulti 0x{id:X}.wsc");
+            string fileName = Path.Combine(Options.OutputPath, $"UopMulti {Utils.FormatExportId(id)}.wsc");
             multi.ExportToWscFile(fileName);
             FileSavedDialog.Show(FindForm(), fileName, "Multi saved successfully.");
         }
@@ -1379,7 +1379,7 @@ namespace UoFiddler.Controls.UserControls
                     continue;
                 }
 
-                string fileName = Path.Combine(dialog.SelectedPath, $"UopMulti 0x{index:X4}.{fileExtension}");
+                string fileName = Path.Combine(dialog.SelectedPath, $"UopMulti {Utils.FormatExportId(index)}.{fileExtension}");
                 using Bitmap bitmap = multi.GetImage(maxHeight);
                 if (bitmap != null)
                 {
@@ -1410,7 +1410,7 @@ namespace UoFiddler.Controls.UserControls
                     continue;
                 }
 
-                multi.ExportToTextFile(Path.Combine(dialog.SelectedPath, $"UopMulti 0x{index:X4}.txt"));
+                multi.ExportToTextFile(Path.Combine(dialog.SelectedPath, $"UopMulti {Utils.FormatExportId(index)}.txt"));
             }
 
             FileSavedDialog.Show(FindForm(), dialog.SelectedPath, "All UOP Multis saved successfully.");
@@ -1436,7 +1436,7 @@ namespace UoFiddler.Controls.UserControls
                     continue;
                 }
 
-                multi.ExportToUOAFile(Path.Combine(dialog.SelectedPath, $"UopMulti 0x{index:X4}.uoa"));
+                multi.ExportToUOAFile(Path.Combine(dialog.SelectedPath, $"UopMulti {Utils.FormatExportId(index)}.uoa"));
             }
 
             FileSavedDialog.Show(FindForm(), dialog.SelectedPath, "All UOP Multis saved successfully.");
@@ -1462,7 +1462,7 @@ namespace UoFiddler.Controls.UserControls
                     continue;
                 }
 
-                multi.ExportToWscFile(Path.Combine(dialog.SelectedPath, $"UopMulti 0x{index:X4}.wsc"));
+                multi.ExportToWscFile(Path.Combine(dialog.SelectedPath, $"UopMulti {Utils.FormatExportId(index)}.wsc"));
             }
 
             FileSavedDialog.Show(FindForm(), dialog.SelectedPath, "All UOP Multis saved successfully.");

--- a/UoFiddler.Controls/UserControls/TexturesControl.cs
+++ b/UoFiddler.Controls/UserControls/TexturesControl.cs
@@ -427,7 +427,7 @@ namespace UoFiddler.Controls.UserControls
             }
 
             string fileExtension = Utils.GetFileExtensionFor(imageFormat);
-            string fileName = Path.Combine(Options.OutputPath, $"Texture 0x{index:X4}.{fileExtension}");
+            string fileName = Path.Combine(Options.OutputPath, $"Texture {Utils.FormatExportId(index)}.{fileExtension}");
 
             using (Bitmap bit = new Bitmap(Textures.GetTexture(index)))
             {
@@ -557,7 +557,7 @@ namespace UoFiddler.Controls.UserControls
                         continue;
                     }
 
-                    string fileName = Path.Combine(dialog.SelectedPath, $"Texture 0x{index:X4}.{fileExtension}");
+                    string fileName = Path.Combine(dialog.SelectedPath, $"Texture {Utils.FormatExportId(index)}.{fileExtension}");
                     var texture = Textures.GetTexture(index);
                     if (texture is null)
                     {

--- a/UoFiddler.Plugin.Compare/UserControls/CompareGumpControl.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareGumpControl.cs
@@ -325,7 +325,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
             }
 
             string path     = Options.OutputPath;
-            string fileName = Path.Combine(path, $"Gump(Sec) 0x{i:X}.bmp");
+            string fileName = Path.Combine(path, $"Gump(Sec) {UoFiddler.Controls.Classes.Utils.FormatExportId(i)}.bmp");
             SecondGump.GetGump(i).Save(fileName, ImageFormat.Bmp);
 
             FileSavedDialog.Show(FindForm(), fileName, "Gump saved successfully.");
@@ -346,7 +346,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
             }
 
             string path     = Options.OutputPath;
-            string fileName = Path.Combine(path, $"Gump(Sec) 0x{i:X}.tiff");
+            string fileName = Path.Combine(path, $"Gump(Sec) {UoFiddler.Controls.Classes.Utils.FormatExportId(i)}.tiff");
             SecondGump.GetGump(i).Save(fileName, ImageFormat.Tiff);
 
             FileSavedDialog.Show(FindForm(), fileName, "Gump saved successfully.");

--- a/UoFiddler.Plugin.Compare/UserControls/CompareItemControl.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareItemControl.cs
@@ -297,7 +297,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
                 return;
             }
 
-            string fileName = Path.Combine(Options.OutputPath, $"Item(Sec) 0x{i:X}.bmp");
+            string fileName = Path.Combine(Options.OutputPath, $"Item(Sec) {UoFiddler.Controls.Classes.Utils.FormatExportId(i)}.bmp");
             SecondArt.GetStatic(i).Save(fileName, ImageFormat.Bmp);
 
             FileSavedDialog.Show(FindForm(), fileName, "Item saved successfully.");
@@ -317,7 +317,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
                 return;
             }
 
-            string fileName = Path.Combine(Options.OutputPath, $"Item(Sec) 0x{i:X}.tiff");
+            string fileName = Path.Combine(Options.OutputPath, $"Item(Sec) {UoFiddler.Controls.Classes.Utils.FormatExportId(i)}.tiff");
             SecondArt.GetStatic(i).Save(fileName, ImageFormat.Tiff);
             FileSavedDialog.Show(FindForm(), fileName, "Item saved successfully.");
         }

--- a/UoFiddler.Plugin.Compare/UserControls/CompareLandControl.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareLandControl.cs
@@ -262,7 +262,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
                 return;
             }
 
-            string fileName = Path.Combine(Options.OutputPath, $"Landtile(Sec) 0x{i:X}.bmp");
+            string fileName = Path.Combine(Options.OutputPath, $"Landtile(Sec) {UoFiddler.Controls.Classes.Utils.FormatExportId(i)}.bmp");
             SecondArt.GetLand(i).Save(fileName, ImageFormat.Bmp);
 
             FileSavedDialog.Show(FindForm(), fileName, "Landtile saved successfully.");
@@ -282,7 +282,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
                 return;
             }
 
-            string fileName = Path.Combine(Options.OutputPath, $"Landtile(Sec) 0x{i:X}.tiff");
+            string fileName = Path.Combine(Options.OutputPath, $"Landtile(Sec) {UoFiddler.Controls.Classes.Utils.FormatExportId(i)}.tiff");
             SecondArt.GetLand(i).Save(fileName, ImageFormat.Tiff);
             FileSavedDialog.Show(FindForm(), fileName, "Landtile saved successfully.");
         }

--- a/UoFiddler.Plugin.Compare/UserControls/CompareTextureControl.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareTextureControl.cs
@@ -251,7 +251,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
                 return;
             }
 
-            string fileName = Path.Combine(Options.OutputPath, $"Texture(Sec) 0x{i:X}.bmp");
+            string fileName = Path.Combine(Options.OutputPath, $"Texture(Sec) {UoFiddler.Controls.Classes.Utils.FormatExportId(i)}.bmp");
             SecondTexture.GetTexture(i).Save(fileName, ImageFormat.Bmp);
             FileSavedDialog.Show(FindForm(), fileName, "Texture saved successfully.");
         }
@@ -270,7 +270,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
                 return;
             }
 
-            string fileName = Path.Combine(Options.OutputPath, $"Texture(Sec) 0x{i:X}.tiff");
+            string fileName = Path.Combine(Options.OutputPath, $"Texture(Sec) {UoFiddler.Controls.Classes.Utils.FormatExportId(i)}.tiff");
             SecondTexture.GetTexture(i).Save(fileName, ImageFormat.Tiff);
             FileSavedDialog.Show(FindForm(), fileName, "Texture saved successfully.");
         }

--- a/UoFiddler.Plugin.UopPacker/UserControls/UopPackerControl.resx
+++ b/UoFiddler.Plugin.UopPacker/UserControls/UopPackerControl.resx
@@ -129,7 +129,7 @@
   <data name="compressionBox.ToolTip" xml:space="preserve">
     <value>Pick the compression that matches the original UOP for the file type:
   Art / Map / Sound: None
-  Gumpart: None on older clients, Mythic on newer clients (New Legacy 7.0.103)
+  Gumpart: None on older clients, Mythic on newer clients (New Legacy 7.0.104)
   MultiCollection: Zlib
 Picking the wrong option produces a UOP that is much larger than the original or unreadable by the client.
 </value>
@@ -137,16 +137,10 @@ Picking the wrong option produces a UOP that is much larger than the original or
   <data name="compressionLabel.ToolTip" xml:space="preserve">
     <value>Pick the compression that matches the original UOP for the file type:
   Art / Map / Sound: None
-  Gumpart: None on older clients, Mythic on newer clients (New Legacy 7.0.103)
+  Gumpart: None on older clients, Mythic on newer clients (New Legacy 7.0.104)
   MultiCollection: Zlib
 Picking the wrong option produces a UOP that is much larger than the original or unreadable by the client.</value>
   </data>
-  <metadata name="ExtractionStatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>519, 17</value>
-  </metadata>
-  <metadata name="compressionTip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <metadata name="MainStatusStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>261, 17</value>
   </metadata>

--- a/UoFiddler/Classes/AppSettings.cs
+++ b/UoFiddler/Classes/AppSettings.cs
@@ -24,6 +24,10 @@ namespace UoFiddler.Classes
 
         public static bool DarkMode { get; set; } = false;
 
+        public static bool ExportFilenameInHex { get; set; } = true;
+
+        public static bool ExportFilenameDecimalPadded { get; set; } = true;
+
         public static void Load()
         {
             if (!File.Exists(FilePath))
@@ -39,6 +43,18 @@ namespace UoFiddler.Classes
             if (elem != null)
             {
                 DarkMode = bool.Parse(elem.GetAttribute("active"));
+            }
+
+            elem = (XmlElement)root?.SelectSingleNode("ExportFilenameInHex");
+            if (elem != null)
+            {
+                ExportFilenameInHex = bool.Parse(elem.GetAttribute("active"));
+            }
+
+            elem = (XmlElement)root?.SelectSingleNode("ExportFilenameDecimalPadded");
+            if (elem != null)
+            {
+                ExportFilenameDecimalPadded = bool.Parse(elem.GetAttribute("active"));
             }
         }
 
@@ -56,6 +72,14 @@ namespace UoFiddler.Classes
 
             XmlElement elem = dom.CreateElement("DarkMode");
             elem.SetAttribute("active", DarkMode.ToString());
+            root.AppendChild(elem);
+
+            elem = dom.CreateElement("ExportFilenameInHex");
+            elem.SetAttribute("active", ExportFilenameInHex.ToString());
+            root.AppendChild(elem);
+
+            elem = dom.CreateElement("ExportFilenameDecimalPadded");
+            elem.SetAttribute("active", ExportFilenameDecimalPadded.ToString());
             root.AppendChild(elem);
 
             dom.AppendChild(root);

--- a/UoFiddler/FiddlerAppContext.cs
+++ b/UoFiddler/FiddlerAppContext.cs
@@ -34,6 +34,8 @@ namespace UoFiddler
             Application.SetCompatibleTextRenderingDefault(false);
             AppSettings.Load();
             Options.DarkMode = AppSettings.DarkMode;
+            Options.ExportFilenameInHex = AppSettings.ExportFilenameInHex;
+            Options.ExportFilenameDecimalPadded = AppSettings.ExportFilenameDecimalPadded;
             if (AppSettings.DarkMode)
             {
                 Application.SetColorMode(SystemColorMode.Dark);

--- a/UoFiddler/Forms/AboutBoxForm.resx
+++ b/UoFiddler/Forms/AboutBoxForm.resx
@@ -118,7 +118,11 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="richTextBox1.Text" xml:space="preserve">
-    <value>Version 4.20.1
+    <value>Version 4.20.2
+- Fixed tooltip client version information in UopPacker.
+- Added option to set export file name template hexadecimal/decimal (defaults to hexadecimal).
+
+Version 4.20.1
 - UopPacker: fix gump extraction, improve sizing of extracted index.
 - UopPacker: fix validation when extracting maps.
 - UopPacker: add progress bars and minor improvements to UI.

--- a/UoFiddler/Forms/OptionsForm.Designer.cs
+++ b/UoFiddler/Forms/OptionsForm.Designer.cs
@@ -62,6 +62,9 @@ namespace UoFiddler.Forms
             label9 = new System.Windows.Forms.Label();
             FocusColorLabel = new System.Windows.Forms.Label();
             SelectedColorLabel = new System.Windows.Forms.Label();
+            radioExportFilenameHex = new System.Windows.Forms.RadioButton();
+            radioExportFilenameDec = new System.Windows.Forms.RadioButton();
+            checkBoxExportFilenameDecPad = new System.Windows.Forms.CheckBox();
             groupBox3 = new System.Windows.Forms.GroupBox();
             map5Nametext = new System.Windows.Forms.TextBox();
             argstext = new System.Windows.Forms.TextBox();
@@ -83,6 +86,7 @@ namespace UoFiddler.Forms
             PreviewBackgroundColorLabel = new System.Windows.Forms.Label();
             PreviewBackgroundColorButton = new System.Windows.Forms.Button();
             buttonClose = new System.Windows.Forms.Button();
+            ExportFilenamesGroupBox = new System.Windows.Forms.GroupBox();
             groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)numericUpDownItemSizeHeight).BeginInit();
             ((System.ComponentModel.ISupportInitialize)numericUpDownItemSizeWidth).BeginInit();
@@ -90,6 +94,7 @@ namespace UoFiddler.Forms
             groupBox3.SuspendLayout();
             groupBox4.SuspendLayout();
             ColorsGroupBox.SuspendLayout();
+            ExportFilenamesGroupBox.SuspendLayout();
             SuspendLayout();
             // 
             // groupBox1
@@ -180,7 +185,7 @@ namespace UoFiddler.Forms
             groupBox2.TabIndex = 3;
             groupBox2.TabStop = false;
             groupBox2.Text = "Misc";
-            //
+            // 
             // checkBoxPolSoundIdOffset
             // 
             checkBoxPolSoundIdOffset.AutoSize = true;
@@ -219,7 +224,7 @@ namespace UoFiddler.Forms
             // 
             // buttonApply
             // 
-            buttonApply.Location = new System.Drawing.Point(318, 476);
+            buttonApply.Location = new System.Drawing.Point(318, 551);
             buttonApply.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             buttonApply.Name = "buttonApply";
             buttonApply.Size = new System.Drawing.Size(88, 27);
@@ -337,6 +342,45 @@ namespace UoFiddler.Forms
             SelectedColorLabel.TabIndex = 14;
             SelectedColorLabel.Text = "Tile Selection";
             toolTip1.SetToolTip(SelectedColorLabel, "ItemSize controls the size of images in items tab");
+            // 
+            // radioExportFilenameHex
+            // 
+            radioExportFilenameHex.AutoSize = true;
+            radioExportFilenameHex.Location = new System.Drawing.Point(10, 21);
+            radioExportFilenameHex.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            radioExportFilenameHex.Name = "radioExportFilenameHex";
+            radioExportFilenameHex.Size = new System.Drawing.Size(214, 19);
+            radioExportFilenameHex.TabIndex = 0;
+            radioExportFilenameHex.TabStop = true;
+            radioExportFilenameHex.Text = "Hexadecimal (e.g. Item 0x00FF.png)";
+            toolTip1.SetToolTip(radioExportFilenameHex, "Exported filenames embed the ID in hexadecimal form.");
+            radioExportFilenameHex.UseVisualStyleBackColor = true;
+            radioExportFilenameHex.CheckedChanged += OnExportFilenameFormatChanged;
+            // 
+            // radioExportFilenameDec
+            // 
+            radioExportFilenameDec.AutoSize = true;
+            radioExportFilenameDec.Location = new System.Drawing.Point(240, 21);
+            radioExportFilenameDec.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            radioExportFilenameDec.Name = "radioExportFilenameDec";
+            radioExportFilenameDec.Size = new System.Drawing.Size(182, 19);
+            radioExportFilenameDec.TabIndex = 1;
+            radioExportFilenameDec.TabStop = true;
+            radioExportFilenameDec.Text = "Decimal (e.g. Item 00255.png)";
+            toolTip1.SetToolTip(radioExportFilenameDec, "Exported filenames embed the ID in decimal form.");
+            radioExportFilenameDec.UseVisualStyleBackColor = true;
+            // 
+            // checkBoxExportFilenameDecPad
+            // 
+            checkBoxExportFilenameDecPad.AutoSize = true;
+            checkBoxExportFilenameDecPad.Location = new System.Drawing.Point(240, 46);
+            checkBoxExportFilenameDecPad.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBoxExportFilenameDecPad.Name = "checkBoxExportFilenameDecPad";
+            checkBoxExportFilenameDecPad.Size = new System.Drawing.Size(146, 19);
+            checkBoxExportFilenameDecPad.TabIndex = 2;
+            checkBoxExportFilenameDecPad.Text = "Pad decimal to 5 digits";
+            toolTip1.SetToolTip(checkBoxExportFilenameDecPad, "When using decimal format, pad the ID with leading zeros so files sort correctly.");
+            checkBoxExportFilenameDecPad.UseVisualStyleBackColor = true;
             // 
             // groupBox3
             // 
@@ -554,7 +598,7 @@ namespace UoFiddler.Forms
             // 
             // buttonClose
             // 
-            buttonClose.Location = new System.Drawing.Point(414, 476);
+            buttonClose.Location = new System.Drawing.Point(414, 551);
             buttonClose.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             buttonClose.Name = "buttonClose";
             buttonClose.Size = new System.Drawing.Size(88, 27);
@@ -563,12 +607,27 @@ namespace UoFiddler.Forms
             buttonClose.UseVisualStyleBackColor = true;
             buttonClose.Click += OnClickClose;
             // 
+            // ExportFilenamesGroupBox
+            // 
+            ExportFilenamesGroupBox.Controls.Add(radioExportFilenameHex);
+            ExportFilenamesGroupBox.Controls.Add(radioExportFilenameDec);
+            ExportFilenamesGroupBox.Controls.Add(checkBoxExportFilenameDecPad);
+            ExportFilenamesGroupBox.Location = new System.Drawing.Point(16, 476);
+            ExportFilenamesGroupBox.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            ExportFilenamesGroupBox.Name = "ExportFilenamesGroupBox";
+            ExportFilenamesGroupBox.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            ExportFilenamesGroupBox.Size = new System.Drawing.Size(486, 69);
+            ExportFilenamesGroupBox.TabIndex = 9;
+            ExportFilenamesGroupBox.TabStop = false;
+            ExportFilenamesGroupBox.Text = "Export Filenames";
+            // 
             // OptionsForm
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(518, 514);
+            ClientSize = new System.Drawing.Size(518, 590);
             Controls.Add(buttonClose);
+            Controls.Add(ExportFilenamesGroupBox);
             Controls.Add(ColorsGroupBox);
             Controls.Add(groupBox4);
             Controls.Add(groupBox3);
@@ -594,6 +653,8 @@ namespace UoFiddler.Forms
             groupBox4.PerformLayout();
             ColorsGroupBox.ResumeLayout(false);
             ColorsGroupBox.PerformLayout();
+            ExportFilenamesGroupBox.ResumeLayout(false);
+            ExportFilenamesGroupBox.PerformLayout();
             ResumeLayout(false);
         }
 
@@ -642,5 +703,9 @@ namespace UoFiddler.Forms
         private System.Windows.Forms.CheckBox checkboxRemoveTileBorder;
         private System.Windows.Forms.Label PreviewBackgroundColorLabel;
         private System.Windows.Forms.Button PreviewBackgroundColorButton;
+        private System.Windows.Forms.GroupBox ExportFilenamesGroupBox;
+        private System.Windows.Forms.RadioButton radioExportFilenameHex;
+        private System.Windows.Forms.RadioButton radioExportFilenameDec;
+        private System.Windows.Forms.CheckBox checkBoxExportFilenameDecPad;
     }
 }

--- a/UoFiddler/Forms/OptionsForm.cs
+++ b/UoFiddler/Forms/OptionsForm.cs
@@ -34,6 +34,11 @@ namespace UoFiddler.Forms
         {
             InitializeComponent();
 
+            radioExportFilenameHex.Checked = AppSettings.ExportFilenameInHex;
+            radioExportFilenameDec.Checked = !AppSettings.ExportFilenameInHex;
+            checkBoxExportFilenameDecPad.Checked = AppSettings.ExportFilenameDecimalPadded;
+            checkBoxExportFilenameDecPad.Enabled = !AppSettings.ExportFilenameInHex;
+
             Icon = Options.GetFiddlerIcon();
 
             _updateAllTileViewsAction = updateAllTileViewsAction;
@@ -186,6 +191,22 @@ namespace UoFiddler.Forms
             {
                 Options.OutputPath = textBoxOutputPath.Text;
             }
+
+            bool newHex = radioExportFilenameHex.Checked;
+            bool newPad = checkBoxExportFilenameDecPad.Checked;
+            if (newHex != AppSettings.ExportFilenameInHex || newPad != AppSettings.ExportFilenameDecimalPadded)
+            {
+                AppSettings.ExportFilenameInHex = newHex;
+                AppSettings.ExportFilenameDecimalPadded = newPad;
+                Options.ExportFilenameInHex = newHex;
+                Options.ExportFilenameDecimalPadded = newPad;
+                AppSettings.Save();
+            }
+        }
+
+        private void OnExportFilenameFormatChanged(object sender, EventArgs e)
+        {
+            checkBoxExportFilenameDecPad.Enabled = !radioExportFilenameHex.Checked;
         }
 
         private void OnClickBrowseOutputPath(object sender, EventArgs e)

--- a/UoFiddler/UoFiddler.csproj
+++ b/UoFiddler/UoFiddler.csproj
@@ -9,9 +9,9 @@
 		<AssemblyTitle>UoFiddler</AssemblyTitle>
 		<Product>UoFiddler</Product>
 		<Copyright>Copyright © 2026</Copyright>
-		<AssemblyVersion>4.20.1</AssemblyVersion>
-		<FileVersion>4.20.1</FileVersion>
-		<Version>4.20.1</Version>
+		<AssemblyVersion>4.20.2</AssemblyVersion>
+		<FileVersion>4.20.2</FileVersion>
+		<Version>4.20.2</Version>
 		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
 	</PropertyGroup>
 	<PropertyGroup>


### PR DESCRIPTION
* Fixed tooltip client version information in UopPacker.
* Added option to set export file name template hexadecimal/decimal (defaults to hexadecimal).
