### PR TITLE
Compare plugins update

### DIFF
--- a/UoFiddler.Plugin.Compare/Classes/SecondArt.cs
+++ b/UoFiddler.Plugin.Compare/Classes/SecondArt.cs
@@ -18,7 +18,12 @@ namespace UoFiddler.Plugin.Compare.Classes
 
         public static void SetFileIndex(string idxPath, string mulPath)
         {
-            _fileIndex = new SecondFileIndex(idxPath, mulPath, 0x14000);
+            SetFileIndex(idxPath, mulPath, null);
+        }
+
+        public static void SetFileIndex(string idxPath, string mulPath, string uopPath)
+        {
+            _fileIndex = new SecondFileIndex(idxPath, mulPath, uopPath, 0x14000, ".tga", 0x13FDC, false);
             _cache = new Bitmap[0x14000];
             FileIndexChanged?.Invoke();
         }

--- a/UoFiddler.Plugin.Compare/Classes/SecondFileAccessor.cs
+++ b/UoFiddler.Plugin.Compare/Classes/SecondFileAccessor.cs
@@ -1,0 +1,281 @@
+/***************************************************************************
+ *
+ * $Author: Turley
+ *
+ * "THE BEER-WARE LICENSE"
+ * As long as you retain this notice you can do whatever you want with
+ * this stuff. If we meet some day, and you think this stuff is worth it,
+ * you can buy me a beer in return.
+ *
+ ***************************************************************************/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using Ultima.Helpers;
+
+namespace UoFiddler.Plugin.Compare.Classes
+{
+    public enum SecondCompressionFlag
+    {
+        None = 0,
+        Zlib = 1,
+        Mythic = 3
+    }
+
+    public interface SecondIEntry
+    {
+        int Lookup { get; set; }
+        int Length { get; set; }
+        int Extra { get; set; }
+        int DecompressedLength { get; set; }
+        int Extra1 { get; set; }
+        int Extra2 { get; set; }
+        SecondCompressionFlag Flag { get; set; }
+    }
+
+    public interface SecondIFileAccessor
+    {
+        SecondIEntry GetEntry(int index);
+        FileStream Stream { get; set; }
+        int IndexLength { get; }
+        long IdxLength { get; }
+        SecondIEntry this[int index] { get; set; }
+    }
+
+    // Layout-sensitive: matches the on-disk 12-byte idx entry. Do not reorder fields.
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct SecondEntry3D : SecondIEntry
+    {
+        public int lookup;
+        public int length;
+        public int extra;
+
+#pragma warning disable S2292
+        public int Lookup { get => lookup; set => lookup = value; }
+        public int Length { get => length; set => length = value; }
+        public int Extra { get => extra; set => extra = value; }
+        public int DecompressedLength { get => length; set => length = value; }
+#pragma warning restore S2292
+
+        public int Extra1
+        {
+            get => (Extra >> 16) & 0xFFFF;
+            set => Extra = (Extra & 0x0000FFFF) | ((value & 0xFFFF) << 16);
+        }
+
+        public int Extra2
+        {
+            get => Extra & 0x0000FFFF;
+            set => Extra = (int)((Extra & 0xFFFF0000) | (uint)(value & 0xFFFF));
+        }
+
+        public SecondCompressionFlag Flag { get => SecondCompressionFlag.None; set { } }
+    }
+
+    public struct SecondEntry6D : SecondIEntry
+    {
+        public int Lookup { get; set; }
+        public int Length { get; set; }
+
+        private int _extra1Backing;
+        private int _extra2Backing;
+
+        public int Extra
+        {
+            get => (_extra1Backing << 16) | _extra2Backing;
+            set
+            {
+                _extra1Backing = (value >> 16) & 0xFFFF;
+                _extra2Backing = value & 0xFFFF;
+            }
+        }
+
+        public int DecompressedLength { get; set; }
+        public int Extra1 { get; set; }
+        public int Extra2 { get; set; }
+        public SecondCompressionFlag Flag { get; set; }
+    }
+
+    public class SecondMulFileAccessor : SecondIFileAccessor
+    {
+        public SecondEntry3D[] Index { get; }
+        public FileStream Stream { get; set; }
+        public long IdxLength { get; }
+        public int IndexLength => Index.Length;
+
+        public SecondIEntry this[int index]
+        {
+            get => Index[index];
+            set => Index[index] = (SecondEntry3D)value;
+        }
+
+        public SecondMulFileAccessor(string idxPath, string mulPath, int length)
+        {
+            Index = new SecondEntry3D[length];
+
+            using (var idx = new FileStream(idxPath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            {
+                Stream = new FileStream(mulPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                int count = (int)(idx.Length / 12);
+                IdxLength = idx.Length;
+
+                GCHandle gc = GCHandle.Alloc(Index, GCHandleType.Pinned);
+                byte[] buffer = new byte[idx.Length];
+                idx.ReadExactly(buffer, 0, (int)idx.Length);
+                Marshal.Copy(buffer, 0, gc.AddrOfPinnedObject(), (int)Math.Min(IdxLength, Index.Length * 12L));
+                gc.Free();
+
+                for (int i = count; i < Index.Length; ++i)
+                {
+                    Index[i].Lookup = -1;
+                    Index[i].Length = -1;
+                    Index[i].Extra = -1;
+                }
+            }
+        }
+
+        public SecondIEntry GetEntry(int index)
+        {
+            if (index < 0 || index >= Index.Length)
+            {
+                return new SecondEntry3D();
+            }
+
+            return Index[index];
+        }
+    }
+
+    public class SecondUopFileAccessor : SecondIFileAccessor
+    {
+        public SecondEntry6D[] Index { get; }
+        public FileStream Stream { get; set; }
+        public long IdxLength { get; }
+        public int IndexLength => Index.Length;
+
+        public SecondIEntry this[int index]
+        {
+            get => Index[index];
+            set => Index[index] = (SecondEntry6D)value;
+        }
+
+        public SecondUopFileAccessor(string path, string uopEntryExtension, int length, int idxLength, bool hasExtra)
+        {
+            Index = new SecondEntry6D[length];
+
+            if (idxLength > 0)
+            {
+                IdxLength = idxLength * 12L;
+            }
+
+            Stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.Read);
+
+            var fileInfo = new FileInfo(path);
+            string uopPattern = fileInfo.Name.Replace(fileInfo.Extension, "").ToLowerInvariant();
+
+            using (var br = new BinaryReader(Stream, System.Text.Encoding.Default, leaveOpen: true))
+            {
+                br.BaseStream.Seek(0, SeekOrigin.Begin);
+
+                if (br.ReadInt32() != 0x50594D)
+                {
+                    throw new ArgumentException("Bad UOP file.");
+                }
+
+                _ = br.ReadUInt32(); // version
+                _ = br.ReadUInt32(); // signature
+                long nextBlock = br.ReadInt64();
+                _ = br.ReadUInt32(); // block capacity
+                _ = br.ReadInt32();  // count
+
+                var hashes = new Dictionary<ulong, int>();
+                for (int i = 0; i < length; i++)
+                {
+                    string entryName = $"build/{uopPattern}/{i:D8}{uopEntryExtension}";
+                    ulong hash = UopUtils.HashFileName(entryName);
+                    hashes.TryAdd(hash, i);
+                }
+
+                br.BaseStream.Seek(nextBlock, SeekOrigin.Begin);
+
+                // UOP entries are sparse; pre-mark all as invalid.
+                for (var i = 0; i < Index.Length; i++)
+                {
+                    Index[i].Lookup = -1;
+                    Index[i].Length = -1;
+                    Index[i].Extra = -1;
+                }
+
+                do
+                {
+                    int filesCount = br.ReadInt32();
+                    nextBlock = br.ReadInt64();
+
+                    for (int i = 0; i < filesCount; i++)
+                    {
+                        long offset = br.ReadInt64();
+                        int headerLength = br.ReadInt32();
+                        int compressedLength = br.ReadInt32();
+                        int decompressedLength = br.ReadInt32();
+                        ulong hash = br.ReadUInt64();
+                        _ = br.ReadUInt32(); // data hash
+                        short flag = br.ReadInt16();
+
+                        if (offset == 0)
+                        {
+                            continue;
+                        }
+
+                        if (!hashes.TryGetValue(hash, out int idx))
+                        {
+                            continue;
+                        }
+
+                        if (idx < 0 || idx > Index.Length)
+                        {
+                            throw new IndexOutOfRangeException("hashes dictionary and files collection have different count of entries!");
+                        }
+
+                        offset += headerLength;
+
+                        if (hasExtra && flag != 3)
+                        {
+                            long curPos = br.BaseStream.Position;
+                            br.BaseStream.Seek(offset, SeekOrigin.Begin);
+                            var extra1 = br.ReadInt32();
+                            var extra2 = br.ReadInt32();
+                            Index[idx].Lookup = (int)(offset + 8);
+                            Index[idx].Length = compressedLength - 8;
+                            Index[idx].DecompressedLength = decompressedLength;
+                            Index[idx].Flag = (SecondCompressionFlag)flag;
+                            Index[idx].Extra = (extra1 << 16) | extra2;
+                            Index[idx].Extra1 = extra1;
+                            Index[idx].Extra2 = extra2;
+                            br.BaseStream.Seek(curPos, SeekOrigin.Begin);
+                        }
+                        else
+                        {
+                            Index[idx].Lookup = (int)offset;
+                            Index[idx].Length = compressedLength;
+                            Index[idx].DecompressedLength = decompressedLength;
+                            Index[idx].Flag = (SecondCompressionFlag)flag;
+                            Index[idx].Extra = 0x0FFFFFFF;
+                        }
+                    }
+                }
+                while (br.BaseStream.Seek(nextBlock, SeekOrigin.Begin) != 0);
+            }
+        }
+
+        public SecondIEntry GetEntry(int index)
+        {
+            if (index < 0 || index >= Index.Length)
+            {
+                return new SecondEntry6D();
+            }
+
+            return Index[index];
+        }
+    }
+}

--- a/UoFiddler.Plugin.Compare/Classes/SecondFileIndex.cs
+++ b/UoFiddler.Plugin.Compare/Classes/SecondFileIndex.cs
@@ -1,77 +1,175 @@
-﻿using System;
+/***************************************************************************
+ *
+ * $Author: Turley
+ *
+ * "THE BEER-WARE LICENSE"
+ * As long as you retain this notice you can do whatever you want with
+ * this stuff. If we meet some day, and you think this stuff is worth it,
+ * you can buy me a beer in return.
+ *
+ ***************************************************************************/
+
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace UoFiddler.Plugin.Compare.Classes
 {
     public sealed class SecondFileIndex
     {
         private readonly string _mulPath;
-        private Entry3D[] Index { get; }
-        private Stream Stream { get; set; }
 
-        public long IdxLength { get; }
+        public SecondIFileAccessor FileAccessor { get; }
+
+        public long IdxLength => FileAccessor?.IdxLength ?? 0;
+        public int IndexLength => FileAccessor?.IndexLength ?? 0;
+
+        public SecondFileIndex(string idxFile, string mulFile, int length)
+            : this(idxFile, mulFile, null, length, ".dat", -1, false)
+        {
+        }
+
+        public SecondFileIndex(string idxFile, string mulFile, string uopFile, int length,
+                               string uopEntryExtension, int idxLength, bool hasExtra)
+        {
+            string idxPath = string.IsNullOrEmpty(idxFile) || !File.Exists(idxFile) ? null : idxFile;
+            string mulPath = string.IsNullOrEmpty(mulFile) || !File.Exists(mulFile) ? null : mulFile;
+            string uopPath = string.IsNullOrEmpty(uopFile) || !File.Exists(uopFile) ? null : uopFile;
+
+            if (uopPath != null)
+            {
+                FileAccessor = new SecondUopFileAccessor(uopPath, uopEntryExtension, length, idxLength, hasExtra);
+                _mulPath = uopPath;
+                return;
+            }
+
+            if (idxPath != null && mulPath != null)
+            {
+                FileAccessor = new SecondMulFileAccessor(idxPath, mulPath, length);
+                _mulPath = mulPath;
+                return;
+            }
+
+            FileAccessor = null;
+            _mulPath = null;
+        }
 
         public Stream Seek(int index, out int length, out int extra)
         {
-            if (index < 0 || index >= Index.Length)
+            length = extra = 0;
+            if (FileAccessor == null || index < 0 || index >= FileAccessor.IndexLength)
             {
-                length = extra = 0;
                 return null;
             }
 
-            Entry3D e = Index[index];
+            SecondIEntry e = FileAccessor.GetEntry(index);
 
             if (e.Lookup < 0 || (e.Lookup > 0 && e.Length == -1))
             {
-                length = extra = 0;
                 return null;
             }
 
             length = e.Length & 0x7FFFFFFF;
             extra = e.Extra;
 
-            // TODO: possible bug wrong ternary or condition?
-            if (Stream?.CanRead != true || !Stream.CanSeek)
-            {
-                Stream = _mulPath == null
-                    ? null
-                    : new FileStream(_mulPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-            }
-
-            if (Stream == null)
+            if (e.Length < 0)
             {
                 length = extra = 0;
                 return null;
             }
 
-            Stream.Seek(e.Lookup, SeekOrigin.Begin);
-            return Stream;
+            if (FileAccessor.Stream?.CanRead != true || !FileAccessor.Stream.CanSeek)
+            {
+                FileAccessor.Stream = _mulPath == null
+                    ? null
+                    : new FileStream(_mulPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            }
+
+            if (FileAccessor.Stream == null)
+            {
+                length = extra = 0;
+                return null;
+            }
+
+            if (FileAccessor.Stream.Length < e.Lookup)
+            {
+                length = extra = 0;
+                return null;
+            }
+
+            FileAccessor.Stream.Seek(e.Lookup, SeekOrigin.Begin);
+            return FileAccessor.Stream;
+        }
+
+        public Stream Seek(int index, ref SecondIEntry entry)
+        {
+            if (FileAccessor == null || index < 0 || index >= FileAccessor.IndexLength)
+            {
+                return null;
+            }
+
+            SecondIEntry e = FileAccessor.GetEntry(index);
+
+            if (e.Lookup < 0)
+            {
+                return null;
+            }
+
+            int length = e.Length & 0x7FFFFFFF;
+            if (length < 0)
+            {
+                return null;
+            }
+
+            entry = e;
+
+            if (e.Length < 0)
+            {
+                return null;
+            }
+
+            if (FileAccessor.Stream?.CanRead != true || !FileAccessor.Stream.CanSeek)
+            {
+                FileAccessor.Stream = _mulPath == null
+                    ? null
+                    : new FileStream(_mulPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            }
+
+            if (FileAccessor.Stream == null)
+            {
+                return null;
+            }
+
+            if (FileAccessor.Stream.Length < e.Lookup)
+            {
+                return null;
+            }
+
+            FileAccessor.Stream.Seek(e.Lookup, SeekOrigin.Begin);
+            return FileAccessor.Stream;
         }
 
         public bool Valid(int index, out int length, out int extra)
         {
-            if (index < 0 || index >= Index.Length)
+            length = extra = 0;
+            if (FileAccessor == null || index < 0 || index >= FileAccessor.IndexLength)
             {
-                length = extra = 0;
                 return false;
             }
 
-            Entry3D e = Index[index];
+            SecondIEntry e = FileAccessor.GetEntry(index);
 
             if (e.Lookup < 0)
             {
-                length = extra = 0;
                 return false;
             }
+
+            length = e.Length & 0x7FFFFFFF;
+            extra = e.Extra;
+
             if (e.Length < 0)
             {
                 length = extra = 0;
                 return false;
             }
-
-            length = e.Length & 0x7FFFFFFF;
-            extra = e.Extra;
 
             if (_mulPath == null || !File.Exists(_mulPath))
             {
@@ -79,69 +177,18 @@ namespace UoFiddler.Plugin.Compare.Classes
                 return false;
             }
 
-            if (Stream?.CanRead != true || !Stream.CanSeek)
+            if (FileAccessor.Stream?.CanRead != true || !FileAccessor.Stream.CanSeek)
             {
-                Stream = new FileStream(_mulPath, FileMode.Open, FileAccess.Read, FileShare.Read);
+                FileAccessor.Stream = new FileStream(_mulPath, FileMode.Open, FileAccess.Read, FileShare.Read);
             }
 
-            if (Stream.Length >= e.Lookup)
+            if (FileAccessor.Stream.Length < e.Lookup)
             {
-                return true;
+                length = extra = 0;
+                return false;
             }
 
-            length = extra = 0;
-            return false;
+            return true;
         }
-
-        public SecondFileIndex(string idxFile, string mulFile, int length)
-        {
-            Index = new Entry3D[length];
-
-            _mulPath = mulFile;
-            if (!File.Exists(idxFile))
-            {
-                idxFile = null;
-            }
-
-            if (!File.Exists(_mulPath))
-            {
-                _mulPath = null;
-            }
-
-            if (idxFile != null && _mulPath != null)
-            {
-                using (FileStream index = new FileStream(idxFile, FileMode.Open, FileAccess.Read, FileShare.Read))
-                {
-                    Stream = new FileStream(_mulPath, FileMode.Open, FileAccess.Read, FileShare.Read);
-
-                    int count = (int)(index.Length / 12);
-                    IdxLength = index.Length;
-
-                    GCHandle gc = GCHandle.Alloc(Index, GCHandleType.Pinned);
-                    byte[] buffer = new byte[index.Length];
-                    index.ReadExactly(buffer, 0, (int)index.Length);
-                    Marshal.Copy(buffer, 0, gc.AddrOfPinnedObject(), (int)Math.Min(IdxLength, length * 12));
-                    gc.Free();
-
-                    for (int i = count; i < length; ++i)
-                    {
-                        Index[i].Lookup = -1;
-                        Index[i].Length = -1;
-                        Index[i].Extra = -1;
-                    }
-                }
-            }
-            else
-            {
-                Stream = null;
-            }
-        }
-    }
-
-    public struct Entry3D
-    {
-        public int Lookup;
-        public int Length;
-        public int Extra;
     }
 }

--- a/UoFiddler.Plugin.Compare/Classes/SecondGump.cs
+++ b/UoFiddler.Plugin.Compare/Classes/SecondGump.cs
@@ -1,7 +1,19 @@
-﻿using System.Drawing;
+/***************************************************************************
+ *
+ * $Author: Turley
+ *
+ * "THE BEER-WARE LICENSE"
+ * As long as you retain this notice you can do whatever you want with
+ * this stuff. If we meet some day, and you think this stuff is worth it,
+ * you can buy me a beer in return.
+ *
+ ***************************************************************************/
+
+using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using Ultima;
+using Ultima.Helpers;
 
 namespace UoFiddler.Plugin.Compare.Classes
 {
@@ -14,18 +26,23 @@ namespace UoFiddler.Plugin.Compare.Classes
 
         public static void SetFileIndex(string idxPath, string mulPath)
         {
-            _fileIndex = new SecondFileIndex(idxPath, mulPath, 0x10000);
+            SetFileIndex(idxPath, mulPath, null);
+        }
+
+        public static void SetFileIndex(string idxPath, string mulPath, string uopPath)
+        {
+            _fileIndex = new SecondFileIndex(idxPath, mulPath, uopPath, 0xFFFF, ".tga", -1, true);
             _cache = new Bitmap[0x10000];
         }
 
-        /// <summary>
-        /// Tests if index is defined
-        /// </summary>
-        /// <param name="index"></param>
-        /// <returns></returns>
         public static bool IsValidIndex(int index)
         {
             if (_fileIndex == null)
+            {
+                return false;
+            }
+
+            if (index < 0 || index >= _cache.Length)
             {
                 return false;
             }
@@ -35,19 +52,26 @@ namespace UoFiddler.Plugin.Compare.Classes
                 return true;
             }
 
-            if (!_fileIndex.Valid(index, out _, out int extra))
+            SecondIEntry entry = null;
+            if (_fileIndex.Seek(index, ref entry) == null || entry == null)
             {
                 return false;
             }
 
-            if (extra == -1)
+            // Compressed UOP entries don't carry width/height in the idx — the
+            // dimensions live inside the decompressed payload. Defer the check.
+            if (entry.Flag >= SecondCompressionFlag.Zlib)
+            {
+                return entry.Length > 0;
+            }
+
+            if (entry.Extra == -1)
             {
                 return false;
             }
 
-            int width = (extra >> 16) & 0xFFFF;
-            int height = extra & 0xFFFF;
-
+            int width = entry.Extra1;
+            int height = entry.Extra2;
             return width > 0 && height > 0;
         }
 
@@ -55,68 +79,68 @@ namespace UoFiddler.Plugin.Compare.Classes
         {
             width = -1;
             height = -1;
-            Stream stream = _fileIndex.Seek(index, out int length, out int extra);
-            if (stream == null)
+
+            if (_fileIndex == null)
             {
                 return null;
             }
 
-            if (extra == -1)
+            SecondIEntry entry = null;
+            Stream stream = _fileIndex.Seek(index, ref entry);
+            if (stream == null || entry == null)
             {
                 return null;
             }
 
-            width = (extra >> 16) & 0xFFFF;
-            height = extra & 0xFFFF;
-            if (width <= 0 || height <= 0)
+            int payloadLength = ReadEntryPayload(stream, entry, out width, out height);
+            if (payloadLength <= 0 || width <= 0 || height <= 0)
             {
                 return null;
             }
 
-            byte[] buffer = new byte[length];
-            stream.ReadExactly(buffer, 0, length);
-            return buffer;
+            // Hand back an exact-sized copy so callers can hash/compare safely.
+            byte[] result = new byte[payloadLength];
+            System.Buffer.BlockCopy(_streamBuffer, 0, result, 0, payloadLength);
+            return result;
         }
 
-        /// <summary>
-        /// Returns Bitmap of index and if verdata patched
-        /// </summary>
-        /// <param name="index"></param>
-        /// <returns></returns>
         public static unsafe Bitmap GetGump(int index)
         {
+            if (_fileIndex == null)
+            {
+                return null;
+            }
+
+            if (index < 0 || index >= _cache.Length)
+            {
+                return null;
+            }
+
             if (_cache[index] != null)
             {
                 return _cache[index];
             }
 
-            Stream stream = _fileIndex.Seek(index, out int length, out int extra);
-            if (stream == null)
+            SecondIEntry entry = null;
+            Stream stream = _fileIndex.Seek(index, ref entry);
+            if (stream == null || entry == null)
             {
                 return null;
             }
 
-            if (extra == -1)
+            int payloadLength = ReadEntryPayload(stream, entry, out int width, out int height);
+            if (payloadLength <= 0 || width <= 0 || height <= 0)
             {
                 return null;
             }
-
-            int width = (extra >> 16) & 0xFFFF;
-            int height = extra & 0xFFFF;
 
             Bitmap bmp = new Bitmap(width, height, PixelFormat.Format16bppArgb1555);
             BitmapData bd = bmp.LockBits(new Rectangle(0, 0, width, height), ImageLockMode.WriteOnly, PixelFormat.Format16bppArgb1555);
-            if (_streamBuffer == null || _streamBuffer.Length < length)
-            {
-                _streamBuffer = new byte[length];
-            }
 
-            stream.ReadExactly(_streamBuffer, 0, length);
-
-            fixed (byte* data = _streamBuffer)
+            fixed (byte* pData = _streamBuffer)
             {
-                int* lookup = (int*)data;
-                ushort* dat = (ushort*)data;
+                int* lookup = (int*)pData;
+                ushort* dat = (ushort*)pData;
 
                 ushort* line = (ushort*)bd.Scan0;
                 int delta = bd.Stride >> 1;
@@ -150,6 +174,66 @@ namespace UoFiddler.Plugin.Compare.Classes
             bmp.UnlockBits(bd);
 
             return Files.CacheData ? _cache[index] = bmp : bmp;
+        }
+
+        /// Reads the pixel-RLE payload for a gump entry into <see cref="_streamBuffer"/>,
+        /// transparently handling uncompressed MUL/UOP and zlib/Mythic-compressed UOP layouts.
+        /// Returns the number of valid bytes at the start of <see cref="_streamBuffer"/>.
+        private static int ReadEntryPayload(Stream stream, SecondIEntry entry, out int width, out int height)
+        {
+            int length = entry.Length;
+            if (length <= 0)
+            {
+                width = height = -1;
+                return 0;
+            }
+
+            if (_streamBuffer == null || _streamBuffer.Length < length)
+            {
+                _streamBuffer = new byte[length];
+            }
+
+            stream.ReadExactly(_streamBuffer, 0, length);
+
+            if (entry.Flag >= SecondCompressionFlag.Zlib)
+            {
+                byte[] compressed = new byte[length];
+                System.Buffer.BlockCopy(_streamBuffer, 0, compressed, 0, length);
+
+                var result = UopUtils.Decompress(compressed);
+                if (!result.success)
+                {
+                    width = height = -1;
+                    return 0;
+                }
+
+                byte[] decompressed = entry.Flag == SecondCompressionFlag.Mythic
+                    ? MythicDecompress.Decompress(result.data)
+                    : result.data;
+
+                if (decompressed == null || decompressed.Length < 8)
+                {
+                    width = height = -1;
+                    return 0;
+                }
+
+                width = (decompressed[3] << 24) | (decompressed[2] << 16) | (decompressed[1] << 8) | decompressed[0];
+                height = (decompressed[7] << 24) | (decompressed[6] << 16) | (decompressed[5] << 8) | decompressed[4];
+                entry.Extra1 = width;
+                entry.Extra2 = height;
+
+                int rleLen = decompressed.Length - 8;
+                if (_streamBuffer.Length < rleLen)
+                {
+                    _streamBuffer = new byte[rleLen];
+                }
+                System.Buffer.BlockCopy(decompressed, 8, _streamBuffer, 0, rleLen);
+                return rleLen;
+            }
+
+            width = entry.Extra1;
+            height = entry.Extra2;
+            return length;
         }
     }
 }

--- a/UoFiddler.Plugin.Compare/Classes/SecondLoadHelper.cs
+++ b/UoFiddler.Plugin.Compare/Classes/SecondLoadHelper.cs
@@ -1,0 +1,87 @@
+/***************************************************************************
+ *
+ * $Author: Turley
+ *
+ * "THE BEER-WARE LICENSE"
+ * As long as you retain this notice you can do whatever you want with
+ * this stuff. If we meet some day, and you think this stuff is worth it,
+ * you can buy me a beer in return.
+ *
+ ***************************************************************************/
+
+using System.IO;
+
+namespace UoFiddler.Plugin.Compare.Classes
+{
+    /// Resolves a user's "Auto/MUL/UOP" mode pick into actual file paths for
+    /// the SecondFileIndex constructor. Returns false with an error message
+    /// when the chosen mode cannot be satisfied by the files on disk.
+    internal static class SecondLoadHelper
+    {
+        public static bool TryResolveArtPaths(string mode, string idxFile, string mulFile, string uopFile,
+            out string resolvedIdx, out string resolvedMul, out string resolvedUop, out string error)
+        {
+            return TryResolvePaths(mode, idxFile, mulFile, uopFile, "art.mul + artidx.mul", "artLegacyMUL.uop",
+                out resolvedIdx, out resolvedMul, out resolvedUop, out error);
+        }
+
+        public static bool TryResolveGumpPaths(string mode, string idxFile, string mulFile, string uopFile,
+            out string resolvedIdx, out string resolvedMul, out string resolvedUop, out string error)
+        {
+            return TryResolvePaths(mode, idxFile, mulFile, uopFile, "gumpart.mul + gumpidx.mul", "gumpartLegacyMUL.uop",
+                out resolvedIdx, out resolvedMul, out resolvedUop, out error);
+        }
+
+        private static bool TryResolvePaths(string mode, string idxFile, string mulFile, string uopFile,
+            string mulDescription, string uopDescription,
+            out string resolvedIdx, out string resolvedMul, out string resolvedUop, out string error)
+        {
+            resolvedIdx = null;
+            resolvedMul = null;
+            resolvedUop = null;
+            error = null;
+
+            bool mulExists = File.Exists(idxFile) && File.Exists(mulFile);
+            bool uopExists = File.Exists(uopFile);
+
+            switch (mode)
+            {
+                case "MUL":
+                    if (!mulExists)
+                    {
+                        error = $"Could not find {mulDescription} in the selected directory.";
+                        return false;
+                    }
+                    resolvedIdx = idxFile;
+                    resolvedMul = mulFile;
+                    return true;
+
+                case "UOP":
+                    if (!uopExists)
+                    {
+                        error = $"Could not find {uopDescription} in the selected directory.";
+                        return false;
+                    }
+                    resolvedUop = uopFile;
+                    return true;
+
+                default: // "Auto" or anything unknown
+                    if (uopExists)
+                    {
+                        resolvedUop = uopFile;
+                        return true;
+                    }
+
+                    if (mulExists)
+                    {
+                        resolvedIdx = idxFile;
+                        resolvedMul = mulFile;
+                        return true;
+                    }
+
+                    error = $"Could not find {uopDescription} or {mulDescription} in the selected directory.";
+                    return false;
+            }
+        }
+    }
+}

--- a/UoFiddler.Plugin.Compare/UserControls/CompareGumpControl.Designer.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareGumpControl.Designer.cs
@@ -57,6 +57,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
             this.button2 = new System.Windows.Forms.Button();
             this.button1 = new System.Windows.Forms.Button();
             this.textBoxSecondDir = new System.Windows.Forms.TextBox();
+            this.comboBoxFileMode = new System.Windows.Forms.ComboBox();
             this.contextMenuStrip1.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBox1)).BeginInit();
@@ -215,6 +216,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
             this.splitContainer1.Panel2.Controls.Add(this.button2);
             this.splitContainer1.Panel2.Controls.Add(this.button1);
             this.splitContainer1.Panel2.Controls.Add(this.textBoxSecondDir);
+            this.splitContainer1.Panel2.Controls.Add(this.comboBoxFileMode);
             this.splitContainer1.Size = new System.Drawing.Size(730, 378);
             this.splitContainer1.SplitterDistance = 320;
             this.splitContainer1.SplitterWidth = 5;
@@ -263,7 +265,21 @@ namespace UoFiddler.Plugin.Compare.UserControls
             this.textBoxSecondDir.Name = "textBoxSecondDir";
             this.textBoxSecondDir.Size = new System.Drawing.Size(179, 23);
             this.textBoxSecondDir.TabIndex = 0;
-            // 
+            //
+            // comboBoxFileMode
+            //
+            this.comboBoxFileMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxFileMode.FormattingEnabled = true;
+            this.comboBoxFileMode.Items.AddRange(new object[] {
+            "Auto",
+            "MUL",
+            "UOP"});
+            this.comboBoxFileMode.Location = new System.Drawing.Point(99, 16);
+            this.comboBoxFileMode.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.comboBoxFileMode.Name = "comboBoxFileMode";
+            this.comboBoxFileMode.Size = new System.Drawing.Size(70, 23);
+            this.comboBoxFileMode.TabIndex = 4;
+            //
             // CompareGumpControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
@@ -306,5 +322,6 @@ namespace UoFiddler.Plugin.Compare.UserControls
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.TextBox textBoxSecondDir;
         private System.Windows.Forms.ToolStripMenuItem tiffToolStripMenuItem;
+        private System.Windows.Forms.ComboBox comboBoxFileMode;
     }
 }

--- a/UoFiddler.Plugin.Compare/UserControls/CompareGumpControl.Designer.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareGumpControl.Designer.cs
@@ -46,6 +46,8 @@ namespace UoFiddler.Plugin.Compare.UserControls
             this.extractAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tiffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.bmpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.jpgToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.pngToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.copyGump2To1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.pictureBox1 = new System.Windows.Forms.PictureBox();
@@ -112,25 +114,41 @@ namespace UoFiddler.Plugin.Compare.UserControls
             // 
             this.extractAsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tiffToolStripMenuItem,
-            this.bmpToolStripMenuItem});
+            this.bmpToolStripMenuItem,
+            this.jpgToolStripMenuItem,
+            this.pngToolStripMenuItem});
             this.extractAsToolStripMenuItem.Name = "extractAsToolStripMenuItem";
             this.extractAsToolStripMenuItem.Size = new System.Drawing.Size(170, 22);
             this.extractAsToolStripMenuItem.Text = "Export Image..";
-            // 
+            //
             // tiffToolStripMenuItem
-            // 
+            //
             this.tiffToolStripMenuItem.Name = "tiffToolStripMenuItem";
             this.tiffToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
             this.tiffToolStripMenuItem.Text = "As Bmp";
             this.tiffToolStripMenuItem.Click += new System.EventHandler(this.Export_Bmp);
-            // 
+            //
             // bmpToolStripMenuItem
-            // 
+            //
             this.bmpToolStripMenuItem.Name = "bmpToolStripMenuItem";
             this.bmpToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
             this.bmpToolStripMenuItem.Text = "As Tiff";
             this.bmpToolStripMenuItem.Click += new System.EventHandler(this.Export_Tiff);
-            // 
+            //
+            // jpgToolStripMenuItem
+            //
+            this.jpgToolStripMenuItem.Name = "jpgToolStripMenuItem";
+            this.jpgToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            this.jpgToolStripMenuItem.Text = "As Jpg";
+            this.jpgToolStripMenuItem.Click += new System.EventHandler(this.Export_Jpg);
+            //
+            // pngToolStripMenuItem
+            //
+            this.pngToolStripMenuItem.Name = "pngToolStripMenuItem";
+            this.pngToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            this.pngToolStripMenuItem.Text = "As Png";
+            this.pngToolStripMenuItem.Click += new System.EventHandler(this.Export_Png);
+            //
             // copyGump2To1ToolStripMenuItem
             // 
             this.copyGump2To1ToolStripMenuItem.Name = "copyGump2To1ToolStripMenuItem";
@@ -278,6 +296,8 @@ namespace UoFiddler.Plugin.Compare.UserControls
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
         private System.Windows.Forms.ToolStripMenuItem copyGump2To1ToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem extractAsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem jpgToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem pngToolStripMenuItem;
         private UoFiddler.Controls.UserControls.TileView.TileViewControl tileView1;
         private UoFiddler.Controls.UserControls.TileView.TileViewControl tileView2;
         private System.Windows.Forms.PictureBox pictureBox1;

--- a/UoFiddler.Plugin.Compare/UserControls/CompareGumpControl.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareGumpControl.cs
@@ -56,6 +56,11 @@ namespace UoFiddler.Plugin.Compare.UserControls
                 tileView1.FocusIndex = 0;
             }
 
+            if (comboBoxFileMode.SelectedIndex < 0)
+            {
+                comboBoxFileMode.SelectedIndex = 0;
+            }
+
             if (!_loaded)
             {
                 ControlEvents.FilePathChangeEvent += OnFilePathChangeEvent;
@@ -217,19 +222,25 @@ namespace UoFiddler.Plugin.Compare.UserControls
 
         private void Load_Click(object sender, EventArgs e)
         {
-            if (textBoxSecondDir.Text == null)
+            if (string.IsNullOrWhiteSpace(textBoxSecondDir.Text))
             {
                 return;
             }
 
-            string path  = textBoxSecondDir.Text;
-            string file  = Path.Combine(path, "gumpart.mul");
-            string file2 = Path.Combine(path, "gumpidx.mul");
-            if (File.Exists(file) && File.Exists(file2))
+            string path = textBoxSecondDir.Text;
+            string mulFile = Path.Combine(path, "gumpart.mul");
+            string idxFile = Path.Combine(path, "gumpidx.mul");
+            string uopFile = Path.Combine(path, "gumpartLegacyMUL.uop");
+
+            if (!SecondLoadHelper.TryResolveGumpPaths(comboBoxFileMode.Text, idxFile, mulFile, uopFile,
+                    out string resolvedIdx, out string resolvedMul, out string resolvedUop, out string error))
             {
-                SecondGump.SetFileIndex(file2, file);
-                LoadSecond();
+                MessageBox.Show(error, "Missing Files", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
             }
+
+            SecondGump.SetFileIndex(resolvedIdx, resolvedMul, resolvedUop);
+            LoadSecond();
         }
 
         private void LoadSecond()

--- a/UoFiddler.Plugin.Compare/UserControls/CompareGumpControl.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareGumpControl.cs
@@ -352,6 +352,48 @@ namespace UoFiddler.Plugin.Compare.UserControls
             FileSavedDialog.Show(FindForm(), fileName, "Gump saved successfully.");
         }
 
+        private void Export_Jpg(object sender, EventArgs e)
+        {
+            int focusIdx = tileView2.FocusIndex;
+            if (focusIdx < 0)
+            {
+                return;
+            }
+
+            int i = _displayIndices[focusIdx];
+            if (!SecondGump.IsValidIndex(i))
+            {
+                return;
+            }
+
+            string path     = Options.OutputPath;
+            string fileName = Path.Combine(path, $"Gump(Sec) {UoFiddler.Controls.Classes.Utils.FormatExportId(i)}.jpg");
+            SecondGump.GetGump(i).Save(fileName, ImageFormat.Jpeg);
+
+            FileSavedDialog.Show(FindForm(), fileName, "Gump saved successfully.");
+        }
+
+        private void Export_Png(object sender, EventArgs e)
+        {
+            int focusIdx = tileView2.FocusIndex;
+            if (focusIdx < 0)
+            {
+                return;
+            }
+
+            int i = _displayIndices[focusIdx];
+            if (!SecondGump.IsValidIndex(i))
+            {
+                return;
+            }
+
+            string path     = Options.OutputPath;
+            string fileName = Path.Combine(path, $"Gump(Sec) {UoFiddler.Controls.Classes.Utils.FormatExportId(i)}.png");
+            SecondGump.GetGump(i).Save(fileName, ImageFormat.Png);
+
+            FileSavedDialog.Show(FindForm(), fileName, "Gump saved successfully.");
+        }
+
         private void OnClickCopy(object sender, EventArgs e)
         {
             int focusIdx = tileView2.FocusIndex;

--- a/UoFiddler.Plugin.Compare/UserControls/CompareItemControl.Designer.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareItemControl.Designer.cs
@@ -47,6 +47,8 @@ namespace UoFiddler.Plugin.Compare.UserControls
             this.extractAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.tiffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.bmpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.jpgToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.pngToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.copyItem2To1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.pictureBoxOrg = new System.Windows.Forms.PictureBox();
             this.pictureBoxSec = new System.Windows.Forms.PictureBox();
@@ -116,25 +118,41 @@ namespace UoFiddler.Plugin.Compare.UserControls
             // 
             this.extractAsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.tiffToolStripMenuItem,
-            this.bmpToolStripMenuItem});
+            this.bmpToolStripMenuItem,
+            this.jpgToolStripMenuItem,
+            this.pngToolStripMenuItem});
             this.extractAsToolStripMenuItem.Name = "extractAsToolStripMenuItem";
             this.extractAsToolStripMenuItem.Size = new System.Drawing.Size(161, 22);
             this.extractAsToolStripMenuItem.Text = "Export Image..";
-            // 
+            //
             // tiffToolStripMenuItem
-            // 
+            //
             this.tiffToolStripMenuItem.Name = "tiffToolStripMenuItem";
             this.tiffToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
             this.tiffToolStripMenuItem.Text = "As Bmp";
             this.tiffToolStripMenuItem.Click += new System.EventHandler(this.ExportAsBmp);
-            // 
+            //
             // bmpToolStripMenuItem
-            // 
+            //
             this.bmpToolStripMenuItem.Name = "bmpToolStripMenuItem";
             this.bmpToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
             this.bmpToolStripMenuItem.Text = "As Tiff";
             this.bmpToolStripMenuItem.Click += new System.EventHandler(this.ExportAsTiff);
-            // 
+            //
+            // jpgToolStripMenuItem
+            //
+            this.jpgToolStripMenuItem.Name = "jpgToolStripMenuItem";
+            this.jpgToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            this.jpgToolStripMenuItem.Text = "As Jpg";
+            this.jpgToolStripMenuItem.Click += new System.EventHandler(this.ExportAsJpg);
+            //
+            // pngToolStripMenuItem
+            //
+            this.pngToolStripMenuItem.Name = "pngToolStripMenuItem";
+            this.pngToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            this.pngToolStripMenuItem.Text = "As Png";
+            this.pngToolStripMenuItem.Click += new System.EventHandler(this.ExportAsPng);
+            //
             // copyItem2To1ToolStripMenuItem
             // 
             this.copyItem2To1ToolStripMenuItem.Name = "copyItem2To1ToolStripMenuItem";
@@ -317,6 +335,8 @@ namespace UoFiddler.Plugin.Compare.UserControls
         private System.Windows.Forms.ContextMenuStrip contextMenuStrip1;
         private System.Windows.Forms.ToolStripMenuItem copyItem2To1ToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem extractAsToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem jpgToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem pngToolStripMenuItem;
         private UoFiddler.Controls.UserControls.TileView.TileViewControl tileViewOrg;
         private UoFiddler.Controls.UserControls.TileView.TileViewControl tileViewSec;
         private System.Windows.Forms.PictureBox pictureBoxOrg;

--- a/UoFiddler.Plugin.Compare/UserControls/CompareItemControl.Designer.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareItemControl.Designer.cs
@@ -59,6 +59,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
             this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.button2 = new System.Windows.Forms.Button();
+            this.comboBoxFileMode = new System.Windows.Forms.ComboBox();
             this.contextMenuStrip1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxOrg)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxSec)).BeginInit();
@@ -283,6 +284,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
             this.splitContainer1.Panel2.Controls.Add(this.textBoxSecondDir);
             this.splitContainer1.Panel2.Controls.Add(this.checkBox1);
             this.splitContainer1.Panel2.Controls.Add(this.button1);
+            this.splitContainer1.Panel2.Controls.Add(this.comboBoxFileMode);
             this.splitContainer1.Size = new System.Drawing.Size(720, 383);
             this.splitContainer1.SplitterDistance = 320;
             this.splitContainer1.SplitterWidth = 5;
@@ -300,9 +302,23 @@ namespace UoFiddler.Plugin.Compare.UserControls
             this.button2.Text = "...";
             this.button2.UseVisualStyleBackColor = true;
             this.button2.Click += new System.EventHandler(this.OnClickBrowse);
-            // 
+            //
+            // comboBoxFileMode
+            //
+            this.comboBoxFileMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxFileMode.FormattingEnabled = true;
+            this.comboBoxFileMode.Items.AddRange(new object[] {
+            "Auto",
+            "MUL",
+            "UOP"});
+            this.comboBoxFileMode.Location = new System.Drawing.Point(5, 16);
+            this.comboBoxFileMode.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.comboBoxFileMode.Name = "comboBoxFileMode";
+            this.comboBoxFileMode.Size = new System.Drawing.Size(70, 23);
+            this.comboBoxFileMode.TabIndex = 10;
+            //
             // CompareItemControl
-            // 
+            //
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.Controls.Add(this.splitContainer1);
@@ -346,5 +362,6 @@ namespace UoFiddler.Plugin.Compare.UserControls
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
         private System.Windows.Forms.TextBox textBoxSecondDir;
         private System.Windows.Forms.ToolStripMenuItem tiffToolStripMenuItem;
+        private System.Windows.Forms.ComboBox comboBoxFileMode;
     }
 }

--- a/UoFiddler.Plugin.Compare/UserControls/CompareItemControl.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareItemControl.cs
@@ -50,6 +50,11 @@ namespace UoFiddler.Plugin.Compare.UserControls
             tileViewOrg.VirtualListSize = _displayIndices.Count;
             tileViewSec.VirtualListSize = 0;
 
+            if (comboBoxFileMode.SelectedIndex < 0)
+            {
+                comboBoxFileMode.SelectedIndex = 0;
+            }
+
             SecondArt.FileIndexChanged += OnSecondArtChanged;
             ControlEvents.FilePathChangeEvent += OnFilePathChangeEvent;
         }
@@ -194,13 +199,19 @@ namespace UoFiddler.Plugin.Compare.UserControls
             }
 
             string path = textBoxSecondDir.Text;
-            string file = Path.Combine(path, "art.mul");
-            string file2 = Path.Combine(path, "artidx.mul");
-            if (File.Exists(file) && File.Exists(file2))
+            string mulFile = Path.Combine(path, "art.mul");
+            string idxFile = Path.Combine(path, "artidx.mul");
+            string uopFile = Path.Combine(path, "artLegacyMUL.uop");
+
+            if (!SecondLoadHelper.TryResolveArtPaths(comboBoxFileMode.Text, idxFile, mulFile, uopFile,
+                    out string resolvedIdx, out string resolvedMul, out string resolvedUop, out string error))
             {
-                SecondArt.SetFileIndex(file2, file);
-                LoadSecond();
+                MessageBox.Show(error, "Missing Files", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
             }
+
+            SecondArt.SetFileIndex(resolvedIdx, resolvedMul, resolvedUop);
+            LoadSecond();
         }
 
         private void LoadSecond()

--- a/UoFiddler.Plugin.Compare/UserControls/CompareItemControl.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareItemControl.cs
@@ -153,6 +153,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
             }
 
             pictureBoxOrg.BackgroundImage = Art.IsValidStatic(i) ? Art.GetStatic(i) : null;
+            pictureBoxSec.BackgroundImage = _secondLoaded && SecondArt.IsValidStatic(i) ? SecondArt.GetStatic(i) : null;
             tileViewOrg.Invalidate();
         }
 
@@ -180,6 +181,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
                 _syncingSelection = false;
             }
 
+            pictureBoxOrg.BackgroundImage = Art.IsValidStatic(i) ? Art.GetStatic(i) : null;
             pictureBoxSec.BackgroundImage = SecondArt.IsValidStatic(i) ? SecondArt.GetStatic(i) : null;
             tileViewSec.Invalidate();
         }
@@ -259,6 +261,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
                 return;
             }
 
+            Cursor.Current = Cursors.WaitCursor;
             int maxId = Math.Max(Art.GetMaxItemId(), SecondArt.GetMaxItemId());
             _displayIndices.Clear();
             if (checkBox1.Checked)
@@ -281,6 +284,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
 
             tileViewOrg.VirtualListSize = _displayIndices.Count;
             tileViewSec.VirtualListSize = _displayIndices.Count;
+            Cursor.Current = Cursors.Default;
         }
 
         private void ExportAsBmp(object sender, EventArgs e)
@@ -319,6 +323,44 @@ namespace UoFiddler.Plugin.Compare.UserControls
 
             string fileName = Path.Combine(Options.OutputPath, $"Item(Sec) {UoFiddler.Controls.Classes.Utils.FormatExportId(i)}.tiff");
             SecondArt.GetStatic(i).Save(fileName, ImageFormat.Tiff);
+            FileSavedDialog.Show(FindForm(), fileName, "Item saved successfully.");
+        }
+
+        private void ExportAsJpg(object sender, EventArgs e)
+        {
+            int focusIdx = tileViewSec.FocusIndex;
+            if (focusIdx < 0)
+            {
+                return;
+            }
+
+            int i = _displayIndices[focusIdx];
+            if (!SecondArt.IsValidStatic(i))
+            {
+                return;
+            }
+
+            string fileName = Path.Combine(Options.OutputPath, $"Item(Sec) {UoFiddler.Controls.Classes.Utils.FormatExportId(i)}.jpg");
+            SecondArt.GetStatic(i).Save(fileName, ImageFormat.Jpeg);
+            FileSavedDialog.Show(FindForm(), fileName, "Item saved successfully.");
+        }
+
+        private void ExportAsPng(object sender, EventArgs e)
+        {
+            int focusIdx = tileViewSec.FocusIndex;
+            if (focusIdx < 0)
+            {
+                return;
+            }
+
+            int i = _displayIndices[focusIdx];
+            if (!SecondArt.IsValidStatic(i))
+            {
+                return;
+            }
+
+            string fileName = Path.Combine(Options.OutputPath, $"Item(Sec) {UoFiddler.Controls.Classes.Utils.FormatExportId(i)}.png");
+            SecondArt.GetStatic(i).Save(fileName, ImageFormat.Png);
             FileSavedDialog.Show(FindForm(), fileName, "Item saved successfully.");
         }
 

--- a/UoFiddler.Plugin.Compare/UserControls/CompareLandControl.Designer.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareLandControl.Designer.cs
@@ -59,6 +59,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
             this.button1 = new System.Windows.Forms.Button();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.button2 = new System.Windows.Forms.Button();
+            this.comboBoxFileMode = new System.Windows.Forms.ComboBox();
             this.tableLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxSec)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.pictureBoxOrg)).BeginInit();
@@ -283,6 +284,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
             this.splitContainer1.Panel2.Controls.Add(this.textBoxSecondDir);
             this.splitContainer1.Panel2.Controls.Add(this.checkBox1);
             this.splitContainer1.Panel2.Controls.Add(this.button1);
+            this.splitContainer1.Panel2.Controls.Add(this.comboBoxFileMode);
             this.splitContainer1.Size = new System.Drawing.Size(719, 430);
             this.splitContainer1.SplitterDistance = 370;
             this.splitContainer1.SplitterWidth = 5;
@@ -300,7 +302,21 @@ namespace UoFiddler.Plugin.Compare.UserControls
             this.button2.Text = "...";
             this.button2.UseVisualStyleBackColor = true;
             this.button2.Click += new System.EventHandler(this.BrowseOnClick);
-            // 
+            //
+            // comboBoxFileMode
+            //
+            this.comboBoxFileMode.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.comboBoxFileMode.FormattingEnabled = true;
+            this.comboBoxFileMode.Items.AddRange(new object[] {
+            "Auto",
+            "MUL",
+            "UOP"});
+            this.comboBoxFileMode.Location = new System.Drawing.Point(5, 13);
+            this.comboBoxFileMode.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.comboBoxFileMode.Name = "comboBoxFileMode";
+            this.comboBoxFileMode.Size = new System.Drawing.Size(70, 23);
+            this.comboBoxFileMode.TabIndex = 10;
+            //
             // CompareLandControl
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
@@ -346,5 +362,6 @@ namespace UoFiddler.Plugin.Compare.UserControls
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.TableLayoutPanel tableLayoutPanel2;
         private System.Windows.Forms.TextBox textBoxSecondDir;
+        private System.Windows.Forms.ComboBox comboBoxFileMode;
     }
 }

--- a/UoFiddler.Plugin.Compare/UserControls/CompareLandControl.Designer.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareLandControl.Designer.cs
@@ -52,6 +52,8 @@ namespace UoFiddler.Plugin.Compare.UserControls
             this.exportImageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.asBmpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.asTiffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.asJpgToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.asPngToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.copyLandTile2To1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.checkBox1 = new System.Windows.Forms.CheckBox();
             this.button1 = new System.Windows.Forms.Button();
@@ -181,25 +183,41 @@ namespace UoFiddler.Plugin.Compare.UserControls
             // 
             this.exportImageToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.asBmpToolStripMenuItem,
-            this.asTiffToolStripMenuItem});
+            this.asTiffToolStripMenuItem,
+            this.asJpgToolStripMenuItem,
+            this.asPngToolStripMenuItem});
             this.exportImageToolStripMenuItem.Name = "exportImageToolStripMenuItem";
             this.exportImageToolStripMenuItem.Size = new System.Drawing.Size(181, 22);
             this.exportImageToolStripMenuItem.Text = "Export Image..";
-            // 
+            //
             // asBmpToolStripMenuItem
-            // 
+            //
             this.asBmpToolStripMenuItem.Name = "asBmpToolStripMenuItem";
             this.asBmpToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
             this.asBmpToolStripMenuItem.Text = "As Bmp";
             this.asBmpToolStripMenuItem.Click += new System.EventHandler(this.ExportAsBmp);
-            // 
+            //
             // asTiffToolStripMenuItem
-            // 
+            //
             this.asTiffToolStripMenuItem.Name = "asTiffToolStripMenuItem";
             this.asTiffToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
             this.asTiffToolStripMenuItem.Text = "As Tiff";
             this.asTiffToolStripMenuItem.Click += new System.EventHandler(this.ExportAsTiff);
-            // 
+            //
+            // asJpgToolStripMenuItem
+            //
+            this.asJpgToolStripMenuItem.Name = "asJpgToolStripMenuItem";
+            this.asJpgToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            this.asJpgToolStripMenuItem.Text = "As Jpg";
+            this.asJpgToolStripMenuItem.Click += new System.EventHandler(this.ExportAsJpg);
+            //
+            // asPngToolStripMenuItem
+            //
+            this.asPngToolStripMenuItem.Name = "asPngToolStripMenuItem";
+            this.asPngToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            this.asPngToolStripMenuItem.Text = "As Png";
+            this.asPngToolStripMenuItem.Click += new System.EventHandler(this.ExportAsPng);
+            //
             // copyLandTile2To1ToolStripMenuItem
             // 
             this.copyLandTile2To1ToolStripMenuItem.Name = "copyLandTile2To1ToolStripMenuItem";
@@ -311,6 +329,8 @@ namespace UoFiddler.Plugin.Compare.UserControls
 
         private System.Windows.Forms.ToolStripMenuItem asBmpToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem asTiffToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem asJpgToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem asPngToolStripMenuItem;
         private System.Windows.Forms.Button btnCopyAllDiff;
         private System.Windows.Forms.Button button1;
         private System.Windows.Forms.Button button2;

--- a/UoFiddler.Plugin.Compare/UserControls/CompareLandControl.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareLandControl.cs
@@ -49,6 +49,11 @@ namespace UoFiddler.Plugin.Compare.UserControls
             tileViewOrg.VirtualListSize = _displayIndices.Count;
             tileViewSec.VirtualListSize = 0;
 
+            if (comboBoxFileMode.SelectedIndex < 0)
+            {
+                comboBoxFileMode.SelectedIndex = 0;
+            }
+
             SecondArt.FileIndexChanged += OnSecondArtChanged;
             ControlEvents.FilePathChangeEvent += OnFilePathChangeEvent;
         }
@@ -171,19 +176,25 @@ namespace UoFiddler.Plugin.Compare.UserControls
 
         private void OnClickLoadSecond(object sender, EventArgs e)
         {
-            if (textBoxSecondDir.Text == null)
+            if (string.IsNullOrWhiteSpace(textBoxSecondDir.Text))
             {
                 return;
             }
 
-            string path  = textBoxSecondDir.Text;
-            string file  = Path.Combine(path, "art.mul");
-            string file2 = Path.Combine(path, "artidx.mul");
-            if (File.Exists(file) && File.Exists(file2))
+            string path = textBoxSecondDir.Text;
+            string mulFile = Path.Combine(path, "art.mul");
+            string idxFile = Path.Combine(path, "artidx.mul");
+            string uopFile = Path.Combine(path, "artLegacyMUL.uop");
+
+            if (!SecondLoadHelper.TryResolveArtPaths(comboBoxFileMode.Text, idxFile, mulFile, uopFile,
+                    out string resolvedIdx, out string resolvedMul, out string resolvedUop, out string error))
             {
-                SecondArt.SetFileIndex(file2, file);
-                LoadSecond();
+                MessageBox.Show(error, "Missing Files", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
             }
+
+            SecondArt.SetFileIndex(resolvedIdx, resolvedMul, resolvedUop);
+            LoadSecond();
         }
 
         private void LoadSecond()

--- a/UoFiddler.Plugin.Compare/UserControls/CompareLandControl.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareLandControl.cs
@@ -142,6 +142,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
             }
 
             pictureBoxOrg.BackgroundImage = Art.IsValidLand(i) ? Art.GetLand(i) : null;
+            pictureBoxSec.BackgroundImage = _secondLoaded && SecondArt.IsValidLand(i) ? SecondArt.GetLand(i) : null;
             tileViewOrg.Invalidate();
         }
 
@@ -163,6 +164,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
             try { tileViewOrg.FocusIndex = e.FocusedItemIndex; }
             finally { _syncingSelection = false; }
 
+            pictureBoxOrg.BackgroundImage = Art.IsValidLand(i) ? Art.GetLand(i) : null;
             pictureBoxSec.BackgroundImage = SecondArt.IsValidLand(i) ? SecondArt.GetLand(i) : null;
             tileViewSec.Invalidate();
         }
@@ -225,6 +227,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
                 return;
             }
 
+            Cursor.Current = Cursors.WaitCursor;
             _displayIndices.Clear();
             if (checkBox1.Checked)
             {
@@ -246,6 +249,7 @@ namespace UoFiddler.Plugin.Compare.UserControls
 
             tileViewOrg.VirtualListSize = _displayIndices.Count;
             tileViewSec.VirtualListSize = _displayIndices.Count;
+            Cursor.Current = Cursors.Default;
         }
 
         private void ExportAsBmp(object sender, EventArgs e)
@@ -284,6 +288,44 @@ namespace UoFiddler.Plugin.Compare.UserControls
 
             string fileName = Path.Combine(Options.OutputPath, $"Landtile(Sec) {UoFiddler.Controls.Classes.Utils.FormatExportId(i)}.tiff");
             SecondArt.GetLand(i).Save(fileName, ImageFormat.Tiff);
+            FileSavedDialog.Show(FindForm(), fileName, "Landtile saved successfully.");
+        }
+
+        private void ExportAsJpg(object sender, EventArgs e)
+        {
+            int focusIdx = tileViewSec.FocusIndex;
+            if (focusIdx < 0)
+            {
+                return;
+            }
+
+            int i = _displayIndices[focusIdx];
+            if (!SecondArt.IsValidLand(i))
+            {
+                return;
+            }
+
+            string fileName = Path.Combine(Options.OutputPath, $"Landtile(Sec) {UoFiddler.Controls.Classes.Utils.FormatExportId(i)}.jpg");
+            SecondArt.GetLand(i).Save(fileName, ImageFormat.Jpeg);
+            FileSavedDialog.Show(FindForm(), fileName, "Landtile saved successfully.");
+        }
+
+        private void ExportAsPng(object sender, EventArgs e)
+        {
+            int focusIdx = tileViewSec.FocusIndex;
+            if (focusIdx < 0)
+            {
+                return;
+            }
+
+            int i = _displayIndices[focusIdx];
+            if (!SecondArt.IsValidLand(i))
+            {
+                return;
+            }
+
+            string fileName = Path.Combine(Options.OutputPath, $"Landtile(Sec) {UoFiddler.Controls.Classes.Utils.FormatExportId(i)}.png");
+            SecondArt.GetLand(i).Save(fileName, ImageFormat.Png);
             FileSavedDialog.Show(FindForm(), fileName, "Landtile saved successfully.");
         }
 

--- a/UoFiddler.Plugin.Compare/UserControls/CompareTextureControl.Designer.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareTextureControl.Designer.cs
@@ -39,283 +39,295 @@ namespace UoFiddler.Plugin.Compare.UserControls
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            this.tileViewOrg = new UoFiddler.Controls.UserControls.TileView.TileViewControl();
-            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
-            this.pictureBoxSec = new System.Windows.Forms.PictureBox();
-            this.pictureBoxOrg = new System.Windows.Forms.PictureBox();
-            this.textBoxSecondDir = new System.Windows.Forms.TextBox();
-            this.tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
-            this.tileViewSec = new UoFiddler.Controls.UserControls.TileView.TileViewControl();
-            this.contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.exportImageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.asBmpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.asTiffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.copyLandTile2To1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.checkBox1 = new System.Windows.Forms.CheckBox();
-            this.button1 = new System.Windows.Forms.Button();
-            this.splitContainer1 = new System.Windows.Forms.SplitContainer();
-            this.CopyAddOnly = new System.Windows.Forms.Button();
-            this.FromLeftToRight = new System.Windows.Forms.Button();
-            this.button2 = new System.Windows.Forms.Button();
-            this.tableLayoutPanel1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxSec)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxOrg)).BeginInit();
-            this.tableLayoutPanel2.SuspendLayout();
-            this.contextMenuStrip1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
-            this.splitContainer1.Panel1.SuspendLayout();
-            this.splitContainer1.Panel2.SuspendLayout();
-            this.splitContainer1.SuspendLayout();
-            this.SuspendLayout();
-            //
+            components = new System.ComponentModel.Container();
+            tileViewOrg = new UoFiddler.Controls.UserControls.TileView.TileViewControl();
+            tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            pictureBoxSec = new System.Windows.Forms.PictureBox();
+            pictureBoxOrg = new System.Windows.Forms.PictureBox();
+            textBoxSecondDir = new System.Windows.Forms.TextBox();
+            tableLayoutPanel2 = new System.Windows.Forms.TableLayoutPanel();
+            tileViewSec = new UoFiddler.Controls.UserControls.TileView.TileViewControl();
+            contextMenuStrip1 = new System.Windows.Forms.ContextMenuStrip(components);
+            exportImageToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            asBmpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            asTiffToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            asJpgToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            asPngToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            copyLandTile2To1ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            checkBox1 = new System.Windows.Forms.CheckBox();
+            button1 = new System.Windows.Forms.Button();
+            splitContainer1 = new System.Windows.Forms.SplitContainer();
+            CopyAddOnly = new System.Windows.Forms.Button();
+            FromLeftToRight = new System.Windows.Forms.Button();
+            button2 = new System.Windows.Forms.Button();
+            tableLayoutPanel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)pictureBoxSec).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)pictureBoxOrg).BeginInit();
+            tableLayoutPanel2.SuspendLayout();
+            contextMenuStrip1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)splitContainer1).BeginInit();
+            splitContainer1.Panel1.SuspendLayout();
+            splitContainer1.Panel2.SuspendLayout();
+            splitContainer1.SuspendLayout();
+            SuspendLayout();
+            // 
             // tileViewOrg
-            //
-            this.tileViewOrg.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tileViewOrg.Location = new System.Drawing.Point(4, 3);
-            this.tileViewOrg.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.tileViewOrg.Name = "tileViewOrg";
-            this.tileViewOrg.Size = new System.Drawing.Size(189, 364);
-            this.tileViewOrg.TabIndex = 0;
-            this.tileViewOrg.TileSize = new System.Drawing.Size(189, 13);
-            this.tileViewOrg.TileMargin = new System.Windows.Forms.Padding(0);
-            this.tileViewOrg.TilePadding = new System.Windows.Forms.Padding(0);
-            this.tileViewOrg.TileBorderWidth = 0f;
-            this.tileViewOrg.TileHighLightOpacity = 0.0;
-            this.tileViewOrg.DrawItem += new System.EventHandler<UoFiddler.Controls.UserControls.TileView.TileViewControl.DrawTileListItemEventArgs>(this.OnDrawItemOrg);
-            this.tileViewOrg.FocusSelectionChanged += new System.EventHandler<UoFiddler.Controls.UserControls.TileView.TileViewControl.ListViewFocusedItemSelectionChangedEventArgs>(this.OnFocusChangedOrg);
-            this.tileViewOrg.SizeChanged += new System.EventHandler(this.OnTileViewSizeChanged);
+            // 
+            tileViewOrg.Dock = System.Windows.Forms.DockStyle.Fill;
+            tileViewOrg.Location = new System.Drawing.Point(4, 3);
+            tileViewOrg.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            tileViewOrg.Name = "tileViewOrg";
+            tileViewOrg.Size = new System.Drawing.Size(189, 363);
+            tileViewOrg.TabIndex = 0;
+            tileViewOrg.TileSize = new System.Drawing.Size(189, 13);
+            tileViewOrg.TileMargin = new System.Windows.Forms.Padding(0);
+            tileViewOrg.TilePadding = new System.Windows.Forms.Padding(0);
+            tileViewOrg.TileBorderWidth = 0f;
+            tileViewOrg.TileHighLightOpacity = 0D;
+            tileViewOrg.FocusSelectionChanged += OnFocusChangedOrg;
+            tileViewOrg.DrawItem += OnDrawItemOrg;
+            tileViewOrg.SizeChanged += OnTileViewSizeChanged;
             // 
             // tableLayoutPanel1
             // 
-            this.tableLayoutPanel1.CellBorderStyle = System.Windows.Forms.TableLayoutPanelCellBorderStyle.Single;
-            this.tableLayoutPanel1.ColumnCount = 1;
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel1.Controls.Add(this.pictureBoxSec, 0, 1);
-            this.tableLayoutPanel1.Controls.Add(this.pictureBoxOrg, 0, 0);
-            this.tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel1.Location = new System.Drawing.Point(201, 3);
-            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-            this.tableLayoutPanel1.RowCount = 2;
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tableLayoutPanel1.Size = new System.Drawing.Size(321, 364);
-            this.tableLayoutPanel1.TabIndex = 7;
+            tableLayoutPanel1.CellBorderStyle = System.Windows.Forms.TableLayoutPanelCellBorderStyle.Single;
+            tableLayoutPanel1.ColumnCount = 1;
+            tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            tableLayoutPanel1.Controls.Add(pictureBoxSec, 0, 1);
+            tableLayoutPanel1.Controls.Add(pictureBoxOrg, 0, 0);
+            tableLayoutPanel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            tableLayoutPanel1.Location = new System.Drawing.Point(201, 3);
+            tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            tableLayoutPanel1.Name = "tableLayoutPanel1";
+            tableLayoutPanel1.RowCount = 2;
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 50F));
+            tableLayoutPanel1.Size = new System.Drawing.Size(321, 363);
+            tableLayoutPanel1.TabIndex = 7;
             // 
             // pictureBoxSec
             // 
-            this.pictureBoxSec.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-            this.pictureBoxSec.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pictureBoxSec.Location = new System.Drawing.Point(5, 185);
-            this.pictureBoxSec.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.pictureBoxSec.Name = "pictureBoxSec";
-            this.pictureBoxSec.Size = new System.Drawing.Size(311, 175);
-            this.pictureBoxSec.TabIndex = 3;
-            this.pictureBoxSec.TabStop = false;
+            pictureBoxSec.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            pictureBoxSec.Dock = System.Windows.Forms.DockStyle.Fill;
+            pictureBoxSec.Location = new System.Drawing.Point(5, 185);
+            pictureBoxSec.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            pictureBoxSec.Name = "pictureBoxSec";
+            pictureBoxSec.Size = new System.Drawing.Size(311, 174);
+            pictureBoxSec.TabIndex = 3;
+            pictureBoxSec.TabStop = false;
             // 
             // pictureBoxOrg
             // 
-            this.pictureBoxOrg.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-            this.pictureBoxOrg.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.pictureBoxOrg.Location = new System.Drawing.Point(5, 4);
-            this.pictureBoxOrg.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.pictureBoxOrg.Name = "pictureBoxOrg";
-            this.pictureBoxOrg.Size = new System.Drawing.Size(311, 174);
-            this.pictureBoxOrg.TabIndex = 2;
-            this.pictureBoxOrg.TabStop = false;
+            pictureBoxOrg.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            pictureBoxOrg.Dock = System.Windows.Forms.DockStyle.Fill;
+            pictureBoxOrg.Location = new System.Drawing.Point(5, 4);
+            pictureBoxOrg.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            pictureBoxOrg.Name = "pictureBoxOrg";
+            pictureBoxOrg.Size = new System.Drawing.Size(311, 174);
+            pictureBoxOrg.TabIndex = 2;
+            pictureBoxOrg.TabStop = false;
             // 
             // textBoxSecondDir
             // 
-            this.textBoxSecondDir.Location = new System.Drawing.Point(28, 13);
-            this.textBoxSecondDir.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.textBoxSecondDir.Name = "textBoxSecondDir";
-            this.textBoxSecondDir.Size = new System.Drawing.Size(168, 23);
-            this.textBoxSecondDir.TabIndex = 4;
+            textBoxSecondDir.Location = new System.Drawing.Point(28, 13);
+            textBoxSecondDir.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBoxSecondDir.Name = "textBoxSecondDir";
+            textBoxSecondDir.Size = new System.Drawing.Size(168, 23);
+            textBoxSecondDir.TabIndex = 4;
             // 
             // tableLayoutPanel2
             // 
-            this.tableLayoutPanel2.ColumnCount = 3;
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 27.27273F));
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 45.45454F));
-            this.tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 27.27273F));
-            this.tableLayoutPanel2.Controls.Add(this.tileViewOrg, 0, 0);
-            this.tableLayoutPanel2.Controls.Add(this.tileViewSec, 2, 0);
-            this.tableLayoutPanel2.Controls.Add(this.tableLayoutPanel1, 1, 0);
-            this.tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
-            this.tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.tableLayoutPanel2.Name = "tableLayoutPanel2";
-            this.tableLayoutPanel2.RowCount = 1;
-            this.tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tableLayoutPanel2.Size = new System.Drawing.Size(724, 370);
-            this.tableLayoutPanel2.TabIndex = 8;
-            //
+            tableLayoutPanel2.ColumnCount = 3;
+            tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 27.27273F));
+            tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 45.45454F));
+            tableLayoutPanel2.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 27.27273F));
+            tableLayoutPanel2.Controls.Add(tileViewOrg, 0, 0);
+            tableLayoutPanel2.Controls.Add(tileViewSec, 2, 0);
+            tableLayoutPanel2.Controls.Add(tableLayoutPanel1, 1, 0);
+            tableLayoutPanel2.Dock = System.Windows.Forms.DockStyle.Fill;
+            tableLayoutPanel2.Location = new System.Drawing.Point(0, 0);
+            tableLayoutPanel2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            tableLayoutPanel2.Name = "tableLayoutPanel2";
+            tableLayoutPanel2.RowCount = 1;
+            tableLayoutPanel2.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            tableLayoutPanel2.Size = new System.Drawing.Size(724, 369);
+            tableLayoutPanel2.TabIndex = 8;
+            // 
             // tileViewSec
-            //
-            this.tileViewSec.ContextMenuStrip = this.contextMenuStrip1;
-            this.tileViewSec.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.tileViewSec.Location = new System.Drawing.Point(530, 3);
-            this.tileViewSec.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.tileViewSec.Name = "tileViewSec";
-            this.tileViewSec.Size = new System.Drawing.Size(190, 364);
-            this.tileViewSec.TabIndex = 1;
-            this.tileViewSec.TileSize = new System.Drawing.Size(190, 13);
-            this.tileViewSec.TileMargin = new System.Windows.Forms.Padding(0);
-            this.tileViewSec.TilePadding = new System.Windows.Forms.Padding(0);
-            this.tileViewSec.TileBorderWidth = 0f;
-            this.tileViewSec.TileHighLightOpacity = 0.0;
-            this.tileViewSec.DrawItem += new System.EventHandler<UoFiddler.Controls.UserControls.TileView.TileViewControl.DrawTileListItemEventArgs>(this.OnDrawItemSec);
-            this.tileViewSec.FocusSelectionChanged += new System.EventHandler<UoFiddler.Controls.UserControls.TileView.TileViewControl.ListViewFocusedItemSelectionChangedEventArgs>(this.OnFocusChangedSec);
-            this.tileViewSec.SizeChanged += new System.EventHandler(this.OnTileViewSizeChanged);
-            this.tileViewSec.MouseDoubleClick += new System.Windows.Forms.MouseEventHandler(this.CopyToLeft_Click);
+            // 
+            tileViewSec.ContextMenuStrip = contextMenuStrip1;
+            tileViewSec.Dock = System.Windows.Forms.DockStyle.Fill;
+            tileViewSec.Location = new System.Drawing.Point(530, 3);
+            tileViewSec.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            tileViewSec.Name = "tileViewSec";
+            tileViewSec.Size = new System.Drawing.Size(190, 363);
+            tileViewSec.TabIndex = 1;
+            tileViewSec.TileSize = new System.Drawing.Size(190, 13);
+            tileViewSec.TileMargin = new System.Windows.Forms.Padding(0);
+            tileViewSec.TilePadding = new System.Windows.Forms.Padding(0);
+            tileViewSec.TileBorderWidth = 0f;
+            tileViewSec.TileHighLightOpacity = 0D;
+            tileViewSec.FocusSelectionChanged += OnFocusChangedSec;
+            tileViewSec.DrawItem += OnDrawItemSec;
+            tileViewSec.SizeChanged += OnTileViewSizeChanged;
+            tileViewSec.MouseDoubleClick += CopyToLeft_Click;
             // 
             // contextMenuStrip1
             // 
-            this.contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.exportImageToolStripMenuItem,
-            this.copyLandTile2To1ToolStripMenuItem});
-            this.contextMenuStrip1.Name = "contextMenuStrip1";
-            this.contextMenuStrip1.Size = new System.Drawing.Size(182, 48);
+            contextMenuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { exportImageToolStripMenuItem, copyLandTile2To1ToolStripMenuItem });
+            contextMenuStrip1.Name = "contextMenuStrip1";
+            contextMenuStrip1.Size = new System.Drawing.Size(182, 48);
             // 
             // exportImageToolStripMenuItem
             // 
-            this.exportImageToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.asBmpToolStripMenuItem,
-            this.asTiffToolStripMenuItem});
-            this.exportImageToolStripMenuItem.Name = "exportImageToolStripMenuItem";
-            this.exportImageToolStripMenuItem.Size = new System.Drawing.Size(181, 22);
-            this.exportImageToolStripMenuItem.Text = "Export Image..";
+            exportImageToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { asBmpToolStripMenuItem, asTiffToolStripMenuItem, asJpgToolStripMenuItem, asPngToolStripMenuItem });
+            exportImageToolStripMenuItem.Name = "exportImageToolStripMenuItem";
+            exportImageToolStripMenuItem.Size = new System.Drawing.Size(181, 22);
+            exportImageToolStripMenuItem.Text = "Export Image..";
             // 
             // asBmpToolStripMenuItem
             // 
-            this.asBmpToolStripMenuItem.Name = "asBmpToolStripMenuItem";
-            this.asBmpToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
-            this.asBmpToolStripMenuItem.Text = "As Bmp";
-            this.asBmpToolStripMenuItem.Click += new System.EventHandler(this.ExportAsBmp);
+            asBmpToolStripMenuItem.Name = "asBmpToolStripMenuItem";
+            asBmpToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            asBmpToolStripMenuItem.Text = "As Bmp";
+            asBmpToolStripMenuItem.Click += ExportAsBmp;
             // 
             // asTiffToolStripMenuItem
             // 
-            this.asTiffToolStripMenuItem.Name = "asTiffToolStripMenuItem";
-            this.asTiffToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
-            this.asTiffToolStripMenuItem.Text = "As Tiff";
-            this.asTiffToolStripMenuItem.Click += new System.EventHandler(this.ExportAsTiff);
+            asTiffToolStripMenuItem.Name = "asTiffToolStripMenuItem";
+            asTiffToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            asTiffToolStripMenuItem.Text = "As Tiff";
+            asTiffToolStripMenuItem.Click += ExportAsTiff;
+            // 
+            // asJpgToolStripMenuItem
+            // 
+            asJpgToolStripMenuItem.Name = "asJpgToolStripMenuItem";
+            asJpgToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            asJpgToolStripMenuItem.Text = "As Jpg";
+            asJpgToolStripMenuItem.Click += ExportAsJpg;
+            // 
+            // asPngToolStripMenuItem
+            // 
+            asPngToolStripMenuItem.Name = "asPngToolStripMenuItem";
+            asPngToolStripMenuItem.Size = new System.Drawing.Size(115, 22);
+            asPngToolStripMenuItem.Text = "As Png";
+            asPngToolStripMenuItem.Click += ExportAsPng;
             // 
             // copyLandTile2To1ToolStripMenuItem
             // 
-            this.copyLandTile2To1ToolStripMenuItem.Name = "copyLandTile2To1ToolStripMenuItem";
-            this.copyLandTile2To1ToolStripMenuItem.Size = new System.Drawing.Size(181, 22);
-            this.copyLandTile2To1ToolStripMenuItem.Text = "Copy LandTile 2 to 1";
-            this.copyLandTile2To1ToolStripMenuItem.Click += new System.EventHandler(this.OnClickCopy);
+            copyLandTile2To1ToolStripMenuItem.Name = "copyLandTile2To1ToolStripMenuItem";
+            copyLandTile2To1ToolStripMenuItem.Size = new System.Drawing.Size(181, 22);
+            copyLandTile2To1ToolStripMenuItem.Text = "Copy LandTile 2 to 1";
+            copyLandTile2To1ToolStripMenuItem.Click += OnClickCopy;
             // 
             // checkBox1
             // 
-            this.checkBox1.AutoSize = true;
-            this.checkBox1.Location = new System.Drawing.Point(343, 15);
-            this.checkBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.checkBox1.Name = "checkBox1";
-            this.checkBox1.Size = new System.Drawing.Size(143, 19);
-            this.checkBox1.TabIndex = 6;
-            this.checkBox1.Text = "Show only Differences";
-            this.checkBox1.UseVisualStyleBackColor = true;
-            this.checkBox1.Click += new System.EventHandler(this.OnChangeShowDiff);
+            checkBox1.AutoSize = true;
+            checkBox1.Location = new System.Drawing.Point(343, 15);
+            checkBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox1.Name = "checkBox1";
+            checkBox1.Size = new System.Drawing.Size(143, 19);
+            checkBox1.TabIndex = 6;
+            checkBox1.Text = "Show only Differences";
+            checkBox1.UseVisualStyleBackColor = true;
+            checkBox1.Click += OnChangeShowDiff;
             // 
             // button1
             // 
-            this.button1.AutoSize = true;
-            this.button1.Location = new System.Drawing.Point(238, 10);
-            this.button1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(99, 29);
-            this.button1.TabIndex = 5;
-            this.button1.Text = "Load Second";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.OnClickLoadSecond);
+            button1.AutoSize = true;
+            button1.Location = new System.Drawing.Point(238, 10);
+            button1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button1.Name = "button1";
+            button1.Size = new System.Drawing.Size(99, 29);
+            button1.TabIndex = 5;
+            button1.Text = "Load Second";
+            button1.UseVisualStyleBackColor = true;
+            button1.Click += OnClickLoadSecond;
             // 
             // splitContainer1
             // 
-            this.splitContainer1.BackColor = System.Drawing.SystemColors.Control;
-            this.splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
-            this.splitContainer1.IsSplitterFixed = true;
-            this.splitContainer1.Location = new System.Drawing.Point(0, 0);
-            this.splitContainer1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.splitContainer1.Name = "splitContainer1";
-            this.splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            splitContainer1.BackColor = System.Drawing.SystemColors.Control;
+            splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            splitContainer1.FixedPanel = System.Windows.Forms.FixedPanel.Panel2;
+            splitContainer1.IsSplitterFixed = true;
+            splitContainer1.Location = new System.Drawing.Point(0, 0);
+            splitContainer1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            splitContainer1.Name = "splitContainer1";
+            splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
             // 
             // splitContainer1.Panel1
             // 
-            this.splitContainer1.Panel1.Controls.Add(this.tableLayoutPanel2);
+            splitContainer1.Panel1.Controls.Add(tableLayoutPanel2);
             // 
             // splitContainer1.Panel2
             // 
-            this.splitContainer1.Panel2.Controls.Add(this.CopyAddOnly);
-            this.splitContainer1.Panel2.Controls.Add(this.FromLeftToRight);
-            this.splitContainer1.Panel2.Controls.Add(this.button2);
-            this.splitContainer1.Panel2.Controls.Add(this.textBoxSecondDir);
-            this.splitContainer1.Panel2.Controls.Add(this.checkBox1);
-            this.splitContainer1.Panel2.Controls.Add(this.button1);
-            this.splitContainer1.Size = new System.Drawing.Size(724, 434);
-            this.splitContainer1.SplitterDistance = 370;
-            this.splitContainer1.SplitterWidth = 5;
-            this.splitContainer1.TabIndex = 10;
+            splitContainer1.Panel2.Controls.Add(CopyAddOnly);
+            splitContainer1.Panel2.Controls.Add(FromLeftToRight);
+            splitContainer1.Panel2.Controls.Add(button2);
+            splitContainer1.Panel2.Controls.Add(textBoxSecondDir);
+            splitContainer1.Panel2.Controls.Add(checkBox1);
+            splitContainer1.Panel2.Controls.Add(button1);
+            splitContainer1.Size = new System.Drawing.Size(724, 434);
+            splitContainer1.SplitterDistance = 369;
+            splitContainer1.SplitterWidth = 5;
+            splitContainer1.TabIndex = 10;
             // 
             // CopyAddOnly
             // 
-            this.CopyAddOnly.Location = new System.Drawing.Point(590, 12);
-            this.CopyAddOnly.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.CopyAddOnly.Name = "CopyAddOnly";
-            this.CopyAddOnly.Size = new System.Drawing.Size(88, 27);
-            this.CopyAddOnly.TabIndex = 9;
-            this.CopyAddOnly.Text = "Copy Added Only";
-            this.CopyAddOnly.UseVisualStyleBackColor = true;
-            this.CopyAddOnly.Click += new System.EventHandler(this.CopyAddOnly_Click);
+            CopyAddOnly.Location = new System.Drawing.Point(590, 12);
+            CopyAddOnly.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            CopyAddOnly.Name = "CopyAddOnly";
+            CopyAddOnly.Size = new System.Drawing.Size(100, 27);
+            CopyAddOnly.TabIndex = 9;
+            CopyAddOnly.Text = "Copy Added Only";
+            CopyAddOnly.UseVisualStyleBackColor = true;
+            CopyAddOnly.Click += CopyAddOnly_Click;
             // 
             // FromLeftToRight
             // 
-            this.FromLeftToRight.Location = new System.Drawing.Point(494, 12);
-            this.FromLeftToRight.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.FromLeftToRight.Name = "FromLeftToRight";
-            this.FromLeftToRight.Size = new System.Drawing.Size(88, 27);
-            this.FromLeftToRight.TabIndex = 8;
-            this.FromLeftToRight.Text = "Copy All Diff";
-            this.FromLeftToRight.UseVisualStyleBackColor = true;
-            this.FromLeftToRight.Click += new System.EventHandler(this.CopyAll_Click);
+            FromLeftToRight.Location = new System.Drawing.Point(494, 12);
+            FromLeftToRight.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            FromLeftToRight.Name = "FromLeftToRight";
+            FromLeftToRight.Size = new System.Drawing.Size(88, 27);
+            FromLeftToRight.TabIndex = 8;
+            FromLeftToRight.Text = "Copy All Diff";
+            FromLeftToRight.UseVisualStyleBackColor = true;
+            FromLeftToRight.Click += CopyAll_Click;
             // 
             // button2
             // 
-            this.button2.AutoSize = true;
-            this.button2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.button2.Location = new System.Drawing.Point(204, 12);
-            this.button2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(26, 25);
-            this.button2.TabIndex = 7;
-            this.button2.Text = "...";
-            this.button2.UseVisualStyleBackColor = true;
-            this.button2.Click += new System.EventHandler(this.BrowseOnClick);
+            button2.AutoSize = true;
+            button2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            button2.Location = new System.Drawing.Point(204, 12);
+            button2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button2.Name = "button2";
+            button2.Size = new System.Drawing.Size(26, 25);
+            button2.TabIndex = 7;
+            button2.Text = "...";
+            button2.UseVisualStyleBackColor = true;
+            button2.Click += BrowseOnClick;
             // 
             // CompareTextureControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.splitContainer1);
-            this.DoubleBuffered = true;
-            this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.Name = "CompareTextureControl";
-            this.Size = new System.Drawing.Size(724, 434);
-            this.Load += new System.EventHandler(this.OnLoad);
-            this.tableLayoutPanel1.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxSec)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxOrg)).EndInit();
-            this.tableLayoutPanel2.ResumeLayout(false);
-            this.contextMenuStrip1.ResumeLayout(false);
-            this.splitContainer1.Panel1.ResumeLayout(false);
-            this.splitContainer1.Panel2.ResumeLayout(false);
-            this.splitContainer1.Panel2.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
-            this.splitContainer1.ResumeLayout(false);
-            this.ResumeLayout(false);
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(splitContainer1);
+            DoubleBuffered = true;
+            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            Name = "CompareTextureControl";
+            Size = new System.Drawing.Size(724, 434);
+            Load += OnLoad;
+            tableLayoutPanel1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)pictureBoxSec).EndInit();
+            ((System.ComponentModel.ISupportInitialize)pictureBoxOrg).EndInit();
+            tableLayoutPanel2.ResumeLayout(false);
+            contextMenuStrip1.ResumeLayout(false);
+            splitContainer1.Panel1.ResumeLayout(false);
+            splitContainer1.Panel2.ResumeLayout(false);
+            splitContainer1.Panel2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)splitContainer1).EndInit();
+            splitContainer1.ResumeLayout(false);
+            ResumeLayout(false);
 
         }
 
@@ -335,6 +347,8 @@ namespace UoFiddler.Plugin.Compare.UserControls
         private System.Windows.Forms.ToolStripMenuItem exportImageToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem asBmpToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem asTiffToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem asJpgToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem asPngToolStripMenuItem;
         private System.Windows.Forms.Button button2;
         private System.Windows.Forms.ToolStripMenuItem copyLandTile2To1ToolStripMenuItem;
         private System.Windows.Forms.Button FromLeftToRight;

--- a/UoFiddler.Plugin.Compare/UserControls/CompareTextureControl.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareTextureControl.cs
@@ -275,6 +275,44 @@ namespace UoFiddler.Plugin.Compare.UserControls
             FileSavedDialog.Show(FindForm(), fileName, "Texture saved successfully.");
         }
 
+        private void ExportAsJpg(object sender, EventArgs e)
+        {
+            int focusIdx = tileViewSec.FocusIndex;
+            if (focusIdx < 0)
+            {
+                return;
+            }
+
+            int i = _displayIndices[focusIdx];
+            if (!SecondTexture.IsValidTexture(i))
+            {
+                return;
+            }
+
+            string fileName = Path.Combine(Options.OutputPath, $"Texture(Sec) {UoFiddler.Controls.Classes.Utils.FormatExportId(i)}.jpg");
+            SecondTexture.GetTexture(i).Save(fileName, ImageFormat.Jpeg);
+            FileSavedDialog.Show(FindForm(), fileName, "Texture saved successfully.");
+        }
+
+        private void ExportAsPng(object sender, EventArgs e)
+        {
+            int focusIdx = tileViewSec.FocusIndex;
+            if (focusIdx < 0)
+            {
+                return;
+            }
+
+            int i = _displayIndices[focusIdx];
+            if (!SecondTexture.IsValidTexture(i))
+            {
+                return;
+            }
+
+            string fileName = Path.Combine(Options.OutputPath, $"Texture(Sec) {UoFiddler.Controls.Classes.Utils.FormatExportId(i)}.png");
+            SecondTexture.GetTexture(i).Save(fileName, ImageFormat.Png);
+            FileSavedDialog.Show(FindForm(), fileName, "Texture saved successfully.");
+        }
+
         private void BrowseOnClick(object sender, EventArgs e)
         {
             using (FolderBrowserDialog dialog = new FolderBrowserDialog())

--- a/UoFiddler.Plugin.Compare/UserControls/CompareTextureControl.resx
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareTextureControl.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">

--- a/UoFiddler.Plugin.Compare/UserControls/CompareTileDataControl.cs
+++ b/UoFiddler.Plugin.Compare/UserControls/CompareTileDataControl.cs
@@ -140,11 +140,13 @@ namespace UoFiddler.Plugin.Compare.UserControls
             // Header row
             var header = new Panel { Dock = DockStyle.Top, Height = 22, BackColor = SystemColors.ControlLight };
             var hLbl = new Label { Text = "Flag", Dock = DockStyle.Fill, TextAlign = ContentAlignment.MiddleLeft, Padding = new Padding(4, 0, 0, 0) };
-            var hSec = new Label { Text = "Sec", Width = 44, Dock = DockStyle.Right, TextAlign = ContentAlignment.MiddleCenter };
             var hOrg = new Label { Text = "Org", Width = 44, Dock = DockStyle.Right, TextAlign = ContentAlignment.MiddleCenter };
+            var hSec = new Label { Text = "Sec", Width = 44, Dock = DockStyle.Right, TextAlign = ContentAlignment.MiddleCenter };
             header.Controls.Add(hLbl);
-            header.Controls.Add(hSec);
+            // Highest index docks first, so hSec (added last) takes the rightmost slot above secChk (col 2),
+            // and hOrg (added second) ends up to its left above orgChk (col 1).
             header.Controls.Add(hOrg);
+            header.Controls.Add(hSec);
 
             // Scrollable area
             var scroll = new Panel { Dock = DockStyle.Fill, AutoScroll = true };

--- a/UoFiddler/Forms/AboutBoxForm.resx
+++ b/UoFiddler/Forms/AboutBoxForm.resx
@@ -118,7 +118,13 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="richTextBox1.Text" xml:space="preserve">
-    <value>Version 4.20.2
+    <value>Version 4.21.0
+- Fixed display order in tiledata - org comes first now.
+- Fixed refreshing of preview images in compare plugins.
+- Added jpg and png to export image in items, land, texture and gump compare plugins.
+- Added UOP file support for compare art, land and gumps. When comparing you can select which type of file you want to use Auto/UOP/MUL (UOP comes before MUL in Auto).
+
+Version 4.20.2
 - Fixed tooltip client version information in UopPacker.
 - Added option to set export file name template hexadecimal/decimal (defaults to hexadecimal).
 

--- a/UoFiddler/UoFiddler.csproj
+++ b/UoFiddler/UoFiddler.csproj
@@ -9,9 +9,9 @@
 		<AssemblyTitle>UoFiddler</AssemblyTitle>
 		<Product>UoFiddler</Product>
 		<Copyright>Copyright © 2026</Copyright>
-		<AssemblyVersion>4.20.2</AssemblyVersion>
-		<FileVersion>4.20.2</FileVersion>
-		<Version>4.20.2</Version>
+		<AssemblyVersion>4.21.0</AssemblyVersion>
+		<FileVersion>4.21.0</FileVersion>
+		<Version>4.21.0</Version>
 		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
 	</PropertyGroup>
 	<PropertyGroup>


### PR DESCRIPTION
* Fixed display order in tiledata - org comes first now.
* Fixed refreshing of preview images in compare plugins.
* Added jpg and png to export image in items, land, texture and gump compare plugins.
* Added UOP file support for compare art, land and gumps. When comparing you can select which type of file you want to use Auto/UOP/MUL (UOP comes before MUL in Auto).